### PR TITLE
Use Salt Submodules

### DIFF
--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -62,8 +62,8 @@ Windows:
         - -master
         - -latest
       oupath: None
-      salt_debug_log: None
-      salt_results_log: None
+      salt_debug_log: C:\Salt\var\log\saltcall.debug.log
+      salt_results_log: C:\Salt\var\log\saltcall.results.log
       saltcontentsource: https://s3.amazonaws.com/systemprep-content/windows/salt/salt-content.zip
       saltinstallerurl: https://s3.amazonaws.com/systemprep-repo/windows/salt/Salt-Minion-2015.8.5-AMD64-Setup.exe
       saltstates: Highstate

--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -35,8 +35,8 @@ Linux:
         - -master
         - -latest
       oupath: None
-      salt_debug_log: /var/log/saltcall.debug.log
-      salt_results_log: /var/log/saltcall.results.log
+      salt_debug_log: None
+      salt_results_log: None
       saltbootstrapsource: None
       saltcontentsource: https://s3.amazonaws.com/systemprep-content/linux/salt/salt-content.zip
       saltinstallmethod: yum
@@ -62,8 +62,8 @@ Windows:
         - -master
         - -latest
       oupath: None
-      salt_debug_log: C:\Salt\var\log\saltcall.debug.log
-      salt_results_log: C:\Salt\var\log\saltcall.results.log
+      salt_debug_log: None
+      salt_results_log: None
       saltcontentsource: https://s3.amazonaws.com/systemprep-content/windows/salt/salt-content.zip
       saltinstallerurl: https://s3.amazonaws.com/systemprep-repo/windows/salt/Salt-Minion-2015.8.5-AMD64-Setup.exe
       saltstates: Highstate

--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -26,7 +26,7 @@ Linux:
       adminusers: None
       computername: None
       entenv: False
-      formulastoinclude:
+      user_formulas:
         #To add other formulas, make sure it is a url to a zipped file as follows:
         #- https://s3.amazonaws.com/salt-formulas/systemprep-formula-master.zip
         #- https://s3.amazonaws.com/salt-formulas/ash-linux-formula-master.zip
@@ -53,7 +53,7 @@ Windows:
       ashrole: MemberServer
       computername: None
       entenv: False
-      formulastoinclude:
+      user_formulas:
         #To add other formulas, make sure it is a url to a zipped file as follows:
         #- https://s3.amazonaws.com/salt-formulas/systemprep-formula-master.zip
         #To "overwrite" submodule formulas, make sure name matches submodule names.

--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -27,11 +27,10 @@ Linux:
       computername: None
       entenv: False
       formulastoinclude:
-        - https://s3.amazonaws.com/salt-formulas/systemprep-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/ash-linux-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/join-domain-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/scc-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/name-computer-formula-master.zip
+        #To add other formulas, make sure it is a url to a zipped file as follows:
+        #- https://s3.amazonaws.com/salt-formulas/systemprep-formula-master.zip
+        #- https://s3.amazonaws.com/salt-formulas/ash-linux-formula-master.zip
+        #To "overwrite" submodule formulas, make sure name matches submodule names.
       formulaterminationstrings:
         - -master
         - -latest
@@ -55,18 +54,10 @@ Windows:
       computername: None
       entenv: False
       formulastoinclude:
-        - https://s3.amazonaws.com/salt-formulas/systemprep-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/ash-windows-formula-master.zip
+        #To add other formulas, make sure it is a url to a zipped file as follows:
+        #- https://s3.amazonaws.com/salt-formulas/systemprep-formula-master.zip
+        #To "overwrite" submodule formulas, make sure name matches submodule names.
         - https://s3.amazonaws.com/salt-formulas/dotnet4-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/emet-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/netbanner-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/mcafee-agent-windows-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/ntp-client-windows-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/splunkforwarder-windows-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/windows-update-agent-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/join-domain-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/scc-formula-master.zip
-        - https://s3.amazonaws.com/salt-formulas/name-computer-formula-master.zip
       formulaterminationstrings:
         - -master
         - -latest

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -117,7 +117,7 @@ class SaltBase(ManagerBase):
 
         return formulas.values()
 
-    def _build_salt_formula(self):
+    def _build_salt_formula(self, extract_dir):
         if self.config['saltcontentsource']:
             self.salt_content_filename = self.config[
                 'saltcontentsource'].split('/')[-1]
@@ -132,7 +132,7 @@ class SaltBase(ManagerBase):
             )
             self.extract_contents(
                 filepath=self.salt_content_file,
-                to_directory=self.salt_srv
+                to_directory=extract_dir
             )
 
         if not os.path.exists(os.path.join(self.salt_conf_path, 'minion.d')):
@@ -300,7 +300,7 @@ class SaltLinux(SaltBase, LinuxManager):
             'pillar_roots': {'base': [str(self.salt_pillar_root)]}
         }
 
-        super(SaltLinux, self)._build_salt_formula()
+        super(SaltLinux, self)._build_salt_formula(self.salt_srv)
 
     def _set_grain(self, grain, value):
         ls_log.info('Setting grain `{0}` ...'.format(grain))
@@ -388,7 +388,7 @@ class SaltWindows(SaltBase, WindowsManager):
             'winrepo_dir': os.sep.join((self.salt_win_repo, 'winrepo'))
         }
 
-        super(SaltWindows, self)._build_salt_formula()
+        super(SaltWindows, self)._build_salt_formula(self.salt_root)
 
     def _set_grain(self, grain, value):
         ws_log.info('Setting grain `{0}` ...'.format(grain))

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -41,8 +41,8 @@ class SaltBase(ManagerBase):
         self.salt_pillar_root = os.sep.join((srv, 'pillar'))
 
     def _prepare_for_install(self, this_log):
-        if self.config['formulastoinclude']:
-            self.formulas_to_include = self.config['formulastoinclude']
+        if self.config['user_formulas']:
+            self.formulas_to_include = self.config['user_formulas']
 
         if self.config['formulaterminationstrings']:
             self.formula_termination_strings = self.config[
@@ -93,7 +93,7 @@ class SaltBase(ManagerBase):
             if os.path.isdir(static_path) and os.listdir(static_path):
                 formulas[formula] = static_path
 
-        # Obtain & extract any Salt formulas specified in formulastoinclude.
+        # Obtain & extract any Salt formulas specified in user_formulas.
         for source_loc in self.formulas_to_include:
             filename = source_loc.split('/')[-1]
             file_loc = os.sep.join((self.working_dir, filename))

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -332,15 +332,15 @@ class SaltWindows(SaltBase, WindowsManager):
         sys_drive = os.environ['systemdrive']
 
         # Set up variables for paths to Salt directories and applications.
-        self.salt_root = os.sep.join(sys_drive, 'Salt')
+        self.salt_root = os.sep.join((sys_drive, 'Salt'))
 
-        self.salt_call = os.sep.join(self.salt_root, 'salt-call.bat')
-        self.salt_conf_path = os.sep.join(self.salt_root, 'conf')
-        self.salt_min_path = os.sep.join(self.salt_root, 'minion')
-        self.salt_srv = os.sep.join(self.salt_root, 'srv')
+        self.salt_call = os.sep.join((self.salt_root, 'salt-call.bat'))
+        self.salt_conf_path = os.sep.join((self.salt_root, 'conf'))
+        self.salt_min_path = os.sep.join((self.salt_root, 'minion'))
+        self.salt_srv = os.sep.join((self.salt_root, 'srv'))
         self.salt_win_repo = os.sep.join((self.salt_srv, 'winrepo'))
         self.salt_working_dir = os.sep.join(
-            [sys_drive, 'Watchmaker', 'WorkingFiles']
+            (sys_drive, 'Watchmaker', 'WorkingFiles')
         )
         self.salt_working_dir_prefix = 'Salt-'
 
@@ -368,10 +368,10 @@ class SaltWindows(SaltBase, WindowsManager):
                 ' needed for installation of Salt in Windows.'
             )
 
-        super(SaltWindows, self)._prepare_for_install()
+        super(SaltWindows, self)._prepare_for_install(ws_log)
 
         # Extra Salt variable for Windows.
-        self.ash_role = self.config['ash_role']
+        self.ash_role = self.config['ashrole']
 
     def _build_salt_formula(self):
         formulas_conf = self._get_formulas_conf()
@@ -385,7 +385,7 @@ class SaltWindows(SaltBase, WindowsManager):
             'file_roots': {'base': file_roots},
             'pillar_roots': {'base': [str(self.salt_pillar_root)]},
             'winrepo_source_dir': 'salt://winrepo',
-            'winrepo_dir': os.sep.join([self.salt_win_repo, 'winrepo'])
+            'winrepo_dir': os.sep.join((self.salt_win_repo, 'winrepo'))
         }
 
         super(SaltWindows, self)._build_salt_formula()
@@ -398,7 +398,7 @@ class SaltWindows(SaltBase, WindowsManager):
         self.load_config(configuration, ws_log)
         self.is_s3_bucket = is_s3_bucket
 
-        self._prepare_for_install(ws_log)
+        self._prepare_for_install()
         self._install_package()
         self._build_salt_formula()
 

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -7,6 +7,7 @@ import sys
 
 import yaml
 
+from watchmaker import static
 from watchmaker.managers.base import LinuxManager, ManagerBase, WindowsManager
 
 ls_log = logging.getLogger('LinuxSalt')
@@ -83,8 +84,15 @@ class SaltBase(ManagerBase):
                     raise SystemError(msg)
 
     def _get_formulas_conf(self):
+        # Append Salt formulas that came with Watchmaker package.
+        formulas_path = os.sep.join(static.__path__[0], 'salt', 'formulas')
+        formulas_conf = [
+            os.sep.join(formulas_path, formula)
+            for formula in os.listdir(formulas_path)
+            if os.path.isdir(os.sep.join(formulas_path, formula))
+        ]
+
         # Obtain & extract any Salt formulas specified in formulastoinclude.
-        formulas_conf = []
         for source_loc in self.formulas_to_include:
             filename = source_loc.split('/')[-1]
             file_loc = os.sep.join((self.working_dir, filename))

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -21,6 +21,7 @@ class SaltBase(ManagerBase):
     salt_file_root = None
     salt_formula_root = None
     salt_srv = None
+    salt_log_dir = None
     salt_working_dir = None
     salt_working_dir_prefix = None
 
@@ -59,10 +60,10 @@ class SaltBase(ManagerBase):
         )
 
         self.salt_results_logfile = self.config['salt_results_log'] or \
-            os.sep.join((self.working_dir, 'salt_call.results.log'))
+            os.sep.join((self.salt_log_dir, 'salt_call.results.log'))
 
         self.salt_debug_logfile = self.config['salt_debug_log'] or \
-            os.sep.join((self.working_dir, 'salt_call.debug.log'))
+            os.sep.join((self.salt_log_dir, 'salt_call.debug.log'))
 
         self.salt_call_args = [
             '--out', 'yaml', '--out-file', self.salt_results_logfile,
@@ -245,6 +246,7 @@ class SaltLinux(SaltBase, LinuxManager):
         self.salt_conf_path = '/etc/salt'
         self.salt_min_path = '/etc/salt/minion'
         self.salt_srv = '/srv/salt'
+        self.salt_log_dir = '/var/log/'
         self.salt_working_dir = '/usr/tmp/'
         self.salt_working_dir_prefix = 'saltinstall'
 
@@ -339,6 +341,7 @@ class SaltWindows(SaltBase, WindowsManager):
         self.salt_min_path = os.sep.join((self.salt_root, 'minion'))
         self.salt_srv = os.sep.join((self.salt_root, 'srv'))
         self.salt_win_repo = os.sep.join((self.salt_srv, 'winrepo'))
+        self.salt_log_dir = os.sep.join((sys_drive, 'Watchmaker', 'Logs'))
         self.salt_working_dir = os.sep.join(
             (sys_drive, 'Watchmaker', 'WorkingFiles')
         )

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -85,11 +85,11 @@ class SaltBase(ManagerBase):
 
     def _get_formulas_conf(self):
         # Append Salt formulas that came with Watchmaker package.
-        formulas_path = os.sep.join(static.__path__[0], 'salt', 'formulas')
+        formulas_path = os.sep.join((static.__path__[0], 'salt', 'formulas'))
         formulas_conf = [
-            os.sep.join(formulas_path, formula)
+            os.sep.join((formulas_path, formula))
             for formula in os.listdir(formulas_path)
-            if os.path.isdir(os.sep.join(formulas_path, formula))
+            if os.path.isdir(os.sep.join((formulas_path, formula)))
         ]
 
         # Obtain & extract any Salt formulas specified in formulastoinclude.


### PR DESCRIPTION
Code updated to use Salt submodules that get packaged with Watchmaker.  Formulas added via config.yaml can still be downloaded and extracted to a temporary location.  If the name matches between the downloaded one and the submodule, the downloaded one is used instead of the submodule.

In addition, this PR fixes a few bugs on the Windows side due to me not testing my last PR properly on a Linux OS and a Windows OS.  :-(

Notice, while testing on Windows with saltstate set to Highstate, command returned a fail and the rest of Watchmaker did not complete.  We might want to explore if we wish to exit Watchmaker when a salt call returns a non-zero response.