### PR TITLE
Moves sys.exit() to the outermost edge of the cli

### DIFF
--- a/src/watchmaker/cli.py
+++ b/src/watchmaker/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 from watchmaker import Prepare
 from watchmaker.logger import prepare_logging
@@ -35,4 +36,4 @@ def main():
     prepare_logging(arguments.log_dir, arguments.verbosity)
 
     systemprep = Prepare(arguments)
-    systemprep.install_system()
+    sys.exit(systemprep.install_system())

--- a/src/watchmaker/cli.py
+++ b/src/watchmaker/cli.py
@@ -1,8 +1,17 @@
 import argparse
+import os
 import sys
 
 from watchmaker import Prepare
 from watchmaker.logger import prepare_logging
+
+
+def _validate_log_dir(log_dir):
+    if os.path.isfile(log_dir):
+        raise argparse.ArgumentTypeError(
+            '"{0}" exists as a file.'.format(log_dir)
+        )
+    return log_dir
 
 
 def main():
@@ -23,6 +32,7 @@ def main():
                             'Highstate, or a comma-separated-string'
                         ))
     parser.add_argument('--log-dir', dest='log_dir', default=None,
+                        type=_validate_log_dir,
                         help='Path to the log directory for logging.'
                         )
     parser.add_argument('-vv', action='count', dest='verbosity', default=0,

--- a/src/watchmaker/exceptions/__init__.py
+++ b/src/watchmaker/exceptions/__init__.py
@@ -1,10 +1,21 @@
+"""Watchmaker exception module."""
+
 import logging
-import sys
 
 
 class ExcLevel:
+    """Define exception levels."""
+
     Error = 1
     Critical = 2
+
+
+class WatchmakerException(Exception):
+    """An unknown error occurred."""
+
+
+class InvalidValue(WatchmakerException):
+    """Passed an invalid value."""
 
 
 def wm_exit(message, level, has_exc):
@@ -14,4 +25,4 @@ def wm_exit(message, level, has_exc):
     if level == ExcLevel.Critical:
         logging.critical(message, exc_info=has_exc)
 
-    sys.exit(1)
+    raise

--- a/src/watchmaker/exceptions/__init__.py
+++ b/src/watchmaker/exceptions/__init__.py
@@ -1,14 +1,5 @@
 """Watchmaker exception module."""
 
-import logging
-
-
-class ExcLevel:
-    """Define exception levels."""
-
-    Error = 1
-    Critical = 2
-
 
 class WatchmakerException(Exception):
     """An unknown error occurred."""
@@ -16,13 +7,3 @@ class WatchmakerException(Exception):
 
 class InvalidValue(WatchmakerException):
     """Passed an invalid value."""
-
-
-def wm_exit(message, level, has_exc):
-    if level == ExcLevel.Error:
-        logging.error(message, exc_info=has_exc)
-
-    if level == ExcLevel.Critical:
-        logging.critical(message, exc_info=has_exc)
-
-    raise

--- a/src/watchmaker/logger/__init__.py
+++ b/src/watchmaker/logger/__init__.py
@@ -1,8 +1,6 @@
 import logging
 import os
 
-from watchmaker.exceptions import ExcLevel, wm_exit
-
 
 def prepare_logging(log_dir, log_level):
     """
@@ -25,11 +23,6 @@ def prepare_logging(log_dir, log_level):
     if not log_dir:
         logging.warning(
             'Watchmaker will not be logging to a file!'
-        )
-    elif os.path.isfile(log_dir):
-        wm_exit(
-            'Log directory passed in is a file. Pass in a directory.',
-            ExcLevel.Error, False
         )
     else:
         if not os.path.exists(log_dir):

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -7,7 +7,7 @@ import subprocess
 import yaml
 
 from watchmaker import static
-from watchmaker.exceptions import ExcLevel, wm_exit
+from watchmaker.exceptions import WatchmakerException
 from watchmaker.managers.base import LinuxManager, ManagerBase, WindowsManager
 
 ls_log = logging.getLogger('LinuxSalt')
@@ -178,10 +178,12 @@ class SaltBase(ManagerBase):
         try:
             self.config = json.loads(configuration)
         except ValueError:
-            wm_exit(
+            msg = (
                 'The configuration passed was not properly formed JSON. '
-                'Execution halted.', ExcLevel.Critical, True
+                'Execution halted.'
             )
+            this_log.critical(msg)
+            raise WatchmakerException(msg)
 
     def process_grains(self, this_log):
         ent_env = {'enterprise_environment': str(self.ent_env)}

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -2,7 +2,6 @@ import json
 import logging
 import re
 
-from watchmaker.exceptions import ExcLevel, wm_exit
 from watchmaker.managers.base import LinuxManager
 
 ylog = logging.getLogger('Yum')
@@ -102,10 +101,12 @@ class Yum(LinuxManager):
         try:
             config = json.loads(configuration)
         except ValueError:
-            wm_exit(
+            msg = (
                 'The configuration passed was not properly formed JSON.'
-                'Execution halted.', ExcLevel.Critical, True
+                'Execution halted.'
             )
+            ylog.critical(msg)
+            raise
 
         if 'yumrepomap' in config and config['yumrepomap']:
             self._repo(config)


### PR DESCRIPTION
Previously, wm_exit() was calling sys.exit() from the exceptions module, which causes watchmaker to behave a bit poorly when watchmaker itself is imported as a library. Watchmaker would force the program to exit, rather than letting the program catch errors and handle its own exit.

Moving sys.exit() to the cli module places the exit at the outermost edge of the watchmaker code, and uses python's raise and exception handling to determine the cli exit code. i.e. if a traceback occurs, the cli exits with 1, otherwise it exits 0.