### PR TITLE
Moves loggers back into class functions

### DIFF
--- a/src/watchmaker/cli.py
+++ b/src/watchmaker/cli.py
@@ -35,9 +35,9 @@ def main():
                         type=_validate_log_dir,
                         help='Path to the log directory for logging.'
                         )
-    parser.add_argument('-vv', action='count', dest='verbosity', default=0,
+    parser.add_argument('-v', action='count', dest='verbosity', default=0,
                         help=(
-                            'Level of debugging: -v for INFO, -vv to '
+                            'Enable verbose logging: -v for INFO, -vv to '
                             'include DEBUG, if option is left out, only '
                             'WARNINGS and higher are logged.'
                         ))

--- a/src/watchmaker/logger/__init__.py
+++ b/src/watchmaker/logger/__init__.py
@@ -10,7 +10,9 @@ def prepare_logging(log_dir, log_level):
             Path of a directory. If this object is not None, then this
             directory will be used to store a log file.
     """
-    logformat = '[%(asctime)s] %(levelname)s: %(message)s'
+    logformat = (
+        '%(asctime)s [%(name)s][%(levelname)-5s][%(process)s]: %(message)s'
+    )
     if log_level == 0:
         level = logging.WARNING
     elif log_level == 1:

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -1,10 +1,7 @@
 import json
-import logging
 import re
 
 from watchmaker.managers.base import LinuxManager
-
-ylog = logging.getLogger('Yum')
 
 
 class Yum(LinuxManager):
@@ -77,9 +74,9 @@ class Yum(LinuxManager):
                 .format(self.dist, self.version)
             )
 
-        ylog.debug('Dist\t\t{0}'.format(self.dist))
-        ylog.debug('Version\t\t{0}'.format(self.version))
-        ylog.debug('EPEL Version\t{0}'.format(self.epel_version))
+        self.log.debug('Dist\t\t{0}'.format(self.dist))
+        self.log.debug('Version\t\t{0}'.format(self.version))
+        self.log.debug('EPEL Version\t{0}'.format(self.epel_version))
 
     def _repo(self, config):
         """
@@ -87,7 +84,7 @@ class Yum(LinuxManager):
         """
         if not isinstance(config['yumrepomap'], list):
             msg = '`yumrepomap` must be a list!'
-            ylog.error(msg, Exception(msg))
+            self.log.error(msg, Exception(msg))
 
     def install(self, configuration):
         """
@@ -105,13 +102,13 @@ class Yum(LinuxManager):
                 'The configuration passed was not properly formed JSON.'
                 'Execution halted.'
             )
-            ylog.critical(msg)
+            self.log.critical(msg)
             raise
 
         if 'yumrepomap' in config and config['yumrepomap']:
             self._repo(config)
         else:
-            ylog.info('yumrepomap did not exist or was empty.')
+            self.log.info('yumrepomap did not exist or was empty.')
 
         self._validate()
 
@@ -119,18 +116,18 @@ class Yum(LinuxManager):
         for repo in config['yumrepomap']:
 
             if repo['dist'] in [self.dist, 'all']:
-                ylog.debug(
+                self.log.debug(
                     '{0} in {1} or all'.format(repo['dist'], self.dist)
                 )
                 if 'epel_version' in repo and \
                         str(repo['epel_version']) != str(self.epel_version):
-                    ylog.debug(
+                    self.log.debug(
                         'Skipping repo - epel_version ({0}) is not valid for '
                         'this repo ({1}).'
                         .format(self.epel_version, repo['url'])
                     )
                 else:
-                    ylog.info(
+                    self.log.info(
                         'All requirements have been validated for repo - {0}.'
                         .format(self.epel_version, repo['url'])
                     )
@@ -140,6 +137,6 @@ class Yum(LinuxManager):
                         url.split('/')[-1])
                     self.download_file(url, repofile)
             else:
-                ylog.debug(
+                self.log.debug(
                     '{0} NOT in {1} or all'.format(repo['dist'], self.dist)
                 )


### PR DESCRIPTION
We had been doing this previously, but using `self.log` felt a little weird, so we defined the loggers globally instead. That is turning out to feel even more weird, with multiple loggers per module (when there are multiple classes logging in one module), and the need to pass the right logger around between different functions.

This changes things back so that watchmaker uses `self.log` when logging within a class. The logger only needed to be defined in two places, Prepare() and ManagerBase(), since all managers and workers inherit from ManagerBase.

Within a class, the logger name is set to include both the module path and the class name:

```
'{0}.{1}'.format(__name__, self.__class__.__name__)
```

The log format is updated as well, so that the logger name and the process number are in the output:

```
%(asctime)s [%(name)s][%(levelname)-5s][%(process)s]: %(message)s
```

The combination results in messages formed like this:

```
2017-01-16 19:15:32,996 [watchmaker.Prepare][INFO ][10084]: Got scripts to execute: ['Yum', 'Salt'].
2017-01-16 19:15:32,998 [watchmaker.managers.base.Yum][DEBUG][10084]: Destination: /etc/yum.repos.d/systemprep-repo-salt-el6.repo
2017-01-16 19:15:36,403 [watchmaker.managers.base.SaltLinux][DEBUG][10084]: /usr/tmp/saltinstall0UD1BH being cleaned up.
2017-01-16 19:15:36,404 [watchmaker.managers.base.SaltLinux][INFO ][10084]: Removed temporary data in working directory -- /usr/tmp/saltinstall0UD1BH
2017-01-16 19:15:36,404 [watchmaker.managers.base.SaltLinux][INFO ][10084]: Exiting cleanup routine...
2017-01-16 19:15:36,404 [watchmaker.Prepare][INFO ][10084]: Stop time: 2017-01-16 19:15:36.404391
```

In addition, there was a bug in the verbosity parameter, such that the count action was not working correctly. That is also fixed.
