### PR TITLE
Removes unnecessary salt formula from default config.yaml

### DIFF
--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -48,7 +48,6 @@ Windows:
         #To add other formulas, make sure it is a url to a zipped file as follows:
         #- https://s3.amazonaws.com/salt-formulas/systemprep-formula-master.zip
         #To "overwrite" submodule formulas, make sure name matches submodule names.
-        - https://s3.amazonaws.com/salt-formulas/dotnet4-formula-master.zip
       formulaterminationstrings:
         - -master
         - -latest


### PR DESCRIPTION
All packaged formulas are pulled in using git submodules,
so it is not necessary to use the option in config.yaml.

Fixes #111