### PR TITLE
Supports an 'All' node in config.yaml

### DIFF
--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -1,3 +1,22 @@
+All:
+  Salt:
+    Parameters:
+      admingroups: None
+      adminusers: None
+      computername: None
+      entenv: False
+      formulaterminationstrings:
+        - -master
+        - -latest
+      oupath: None
+      saltstates: Highstate
+      sourceiss3bucket: False
+      user_formulas:
+        #To add other formulas, make sure it is a url to a zipped file as follows:
+        #- https://s3.amazonaws.com/salt-formulas/systemprep-formula-master.zip
+        #- https://s3.amazonaws.com/salt-formulas/ash-linux-formula-master.zip
+        #To "overwrite" submodule formulas, make sure name matches submodule names.
+
 Linux:
   Yum:
     Parameters:
@@ -20,49 +39,20 @@ Linux:
 
   Salt:
     Parameters:
-      admingroups: None
-      adminusers: None
-      computername: None
-      entenv: False
-      user_formulas:
-        #To add other formulas, make sure it is a url to a zipped file as follows:
-        #- https://s3.amazonaws.com/salt-formulas/systemprep-formula-master.zip
-        #- https://s3.amazonaws.com/salt-formulas/ash-linux-formula-master.zip
-        #To "overwrite" submodule formulas, make sure name matches submodule names.
-      formulaterminationstrings:
-        - -master
-        - -latest
-      oupath: None
       salt_debug_log: None
       salt_results_log: None
       saltbootstrapsource: None
       saltcontentsource: https://s3.amazonaws.com/systemprep-content/linux/salt/salt-content.zip
       saltinstallmethod: yum
       saltgitrepo: None
-      saltstates: Highstate
       saltversion: None
-      sourceiss3bucket: False
 
 Windows:
   Salt:
     Parameters:
-      admingroups: None
-      adminusers: None
       ashrole: MemberServer
-      computername: None
-      entenv: False
-      user_formulas:
-        #To add other formulas, make sure it is a url to a zipped file as follows:
-        #- https://s3.amazonaws.com/salt-formulas/systemprep-formula-master.zip
-        #To "overwrite" submodule formulas, make sure name matches submodule names.
-      formulaterminationstrings:
-        - -master
-        - -latest
-      oupath: None
       salt_debug_log: None
       salt_results_log: None
       saltcontentsource: https://s3.amazonaws.com/systemprep-content/windows/salt/salt-content.zip
       saltinstallerurl: https://s3.amazonaws.com/systemprep-repo/windows/salt/Salt-Minion-2016.3.4-AMD64-Setup.exe
-      saltstates: Highstate
       saltworkingdir: SystemContent\Windows\Salt\
-      sourceiss3bucket: False


### PR DESCRIPTION
The `All` node contains workers and worker parameters that are common to all platforms. The system-specific config is merged into the `All` config. If the `All` node is absent, then the system-specific config is used by itself. If both `All` and the system-specific config are missing, an exception is raised.