### PR TITLE
Aligns cli syntax for extra_arguments

### DIFF
--- a/src/watchmaker/__init__.py
+++ b/src/watchmaker/__init__.py
@@ -187,9 +187,12 @@ class Client(object):
         # All remaining arguments are worker_args
         worker_args = arguments
 
-        # Convert extra_arguments to a dict and merge it with worker_args
+        # Convert extra_arguments to a dict and merge it with worker_args.
+        # Leading hypens are removed, and other hyphens are converted to
+        # underscores
         worker_args.update(dict(
-            (k.lstrip('-'), v) for k, v in zip(*[iter(extra_arguments)] * 2)
+            (k.lstrip('-').replace('-', '_'), v) for k, v in zip(
+                *[iter(extra_arguments)] * 2)
         ))
         # Set self.worker_args, removing `None` values from worker_args
         self.worker_args = dict(

--- a/tox.ini
+++ b/tox.ini
@@ -44,7 +44,6 @@ commands =
 [testenv:check]
 deps =
     {toxinidir}
-    docutils
     check-manifest>=0.33
     flake8
     flake8-bugbear
@@ -56,6 +55,7 @@ deps =
     pep8-naming
     pygments
     pylint
+    bleach>=1.4,<2
     readme-renderer
 skip_install = true
 commands =


### PR DESCRIPTION
Previously, using extra_arguments from the cli required passing
arguments like so:

`--content_source <foo>`

The internal underscore makes this unlike other cli opts.

This patch replaces internal hyphens with an underscore, so
extra_arguments can now be passed the same as normal cli opts:

`--content-source <foo>`

Fixes #164