### PR TITLE
Returns full path to formula directory

### DIFF
--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -181,8 +181,10 @@ class SaltBase(ManagerBase):
                         shutil.rmtree(new_formula_dir)
                     shutil.move(formula_loc, new_formula_dir)
 
-        return [x for x in os.listdir(self.salt_formula_root)
-                if os.path.isdir(x)]
+        return [
+            os.path.join(self.salt_formula_root, x) for x in next(os.walk(
+                self.salt_formula_root))[1]
+        ]
 
     def _build_salt_formula(self, extract_dir):
         if self.content_source:


### PR DESCRIPTION
os.listdir only returns the name of the directory, not the full
path to the directory. The isdir() test was then failing, so the
method was always returning an empty list.

This patch uses `next(os.walk(salt_formula_root))[1]` to get all
the directories in the first level of salt_formula_root, which
again returns only the names of the directories. The list
comprehension joins them with salt_formula_root to return the full
path.

Fixes #180