### PR TITLE
Fixes error on EL6 with pip v7.1.0

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -67,7 +67,8 @@ PYPI_URL=https://pypi.org/simple
 yum -y --enablerepo=epel install python-pip
 
 # Install watchmaker
-pip install --index-url $PYPI_URL --upgrade pip setuptools watchmaker
+pip install --index-url $PYPI_URL --upgrade pip setuptools
+pip install --index-url $PYPI_URL --upgrade watchmaker
 
 # Run watchmaker
 watchmaker -vv --log-dir=/var/log/watchmaker
@@ -91,7 +92,8 @@ $BootstrapFile = "${Env:Temp}\$(${BootstrapUrl}.split("/")[-1])"
 & $BootstrapFile -PythonUrl $PythonUrl -Verbose -ErrorAction Stop
 
 # Install watchmaker
-pip install --index-url $PypiUrl --upgrade pip setuptools watchmaker
+pip install --index-url $PypiUrl --upgrade pip setuptools
+pip install --index-url $PypiUrl --upgrade watchmaker
 
 # Run watchmaker
 watchmaker -vv --log-dir=C:\Watchmaker\Logs


### PR DESCRIPTION
The version of pip in epel for EL6 is v7.1.0, which thinks the
pypi.org index is an external link. That caused the install to
fail.

This patch changes the usage doc to install/upgrade pip first,
then to install watchmaker using the newer version of pip, which
does not have the same problem with the pypi.org index.