### PR TITLE
Streams stdout/stderr to logger using threads

### DIFF
--- a/src/watchmaker/managers/base.py
+++ b/src/watchmaker/managers/base.py
@@ -186,8 +186,11 @@ class ManagerBase(object):
 
     @staticmethod
     def _pipe_logger(pipe, logger, prefix_msg=''):
-        for line in iter(pipe.readline, b''):
-            logger('%s%s', prefix_msg, line.rstrip())
+        try:
+            for line in iter(pipe.readline, b''):
+                logger('%s%s', prefix_msg, line.rstrip())
+        finally:
+            pipe.close()
 
     def call_process(self, cmd):
         """
@@ -223,8 +226,6 @@ class ManagerBase(object):
 
         stdout_reader.join()
         stderr_reader.join()
-        process.stdout.close()
-        process.stderr.close()
 
         returncode = process.wait()
 

--- a/src/watchmaker/managers/base.py
+++ b/src/watchmaker/managers/base.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import tarfile
 import tempfile
+import threading
 import zipfile
 
 from six import add_metaclass
@@ -183,6 +184,11 @@ class ManagerBase(object):
         self.working_dir = working_dir
         os.umask(original_umask)
 
+    @staticmethod
+    def _pipe_logger(pipe, logger, prefix_msg=''):
+        for line in iter(pipe.readline, b''):
+            logger('%s%s', prefix_msg, line.rstrip())
+
     def call_process(self, cmd):
         """
         Execute a shell command.
@@ -202,14 +208,27 @@ class ManagerBase(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
-        stdout, stderr = process.communicate()
 
-        for line in stdout.splitlines():
-            self.log.debug('Command stdout: %s', line)
-        for line in stderr.splitlines():
-            self.log.error('Command stderr: %s', line)
+        stdout_reader = threading.Thread(
+            target=self._pipe_logger,
+            args=(process.stdout, self.log.debug, 'Command stdout: '))
+        stdout_reader.daemon = True
+        stdout_reader.start()
 
-        if process.returncode != 0:
+        stderr_reader = threading.Thread(
+            target=self._pipe_logger,
+            args=(process.stderr, self.log.error, 'Command stderr: '))
+        stderr_reader.daemon = True
+        stderr_reader.start()
+
+        stdout_reader.join()
+        stderr_reader.join()
+        process.stdout.close()
+        process.stderr.close()
+
+        returncode = process.wait()
+
+        if returncode != 0:
             msg = 'Command failed! Exit code={0}, cmd={1}'.format(
                 process.returncode, cmd)
             self.log.critical(msg)


### PR DESCRIPTION
subprocess.communicate() blocks and reads all the output into
memory before returning. It is safe in that it uses threads to
avoid deadlocks when capturing both stdout and stderr in a pipe.

This patch uses threads to read the stdout and stderr pipes, and
to log the output as it is generated. This approach continues to
avoid deadlocks, but also avoids blocking and reading all the output
into memory.