### PR TITLE
Logs unhandled exceptions by overriding sys.excepthook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,8 +86,9 @@ setup(
         ]
     },
     install_requires=[
+        "argparse",
+        "futures",
         "six",
         "PyYAML",
-        "argparse"
     ]
 )

--- a/src/watchmaker/cli.py
+++ b/src/watchmaker/cli.py
@@ -8,7 +8,7 @@ import os
 import sys
 
 import watchmaker
-from watchmaker.logger import prepare_logging
+from watchmaker.logger import exception_hook, prepare_logging
 
 
 def _validate_log_dir(log_dir):
@@ -100,6 +100,9 @@ def main():
 
     arguments, extra_arguments = parser.parse_known_args()
     prepare_logging(arguments.log_dir, arguments.verbosity)
+
+    # Setup excepthook to log all unhandled exceptions
+    sys.excepthook = exception_hook
 
     watchmaker_arguments = watchmaker.Arguments(**dict(
         extra_arguments=extra_arguments,

--- a/src/watchmaker/logger/__init__.py
+++ b/src/watchmaker/logger/__init__.py
@@ -16,6 +16,16 @@ LOG_LEVELS = collections.defaultdict(
 )
 
 
+def exception_hook(exc_type, exc_value, exc_traceback):
+    """Hook for sys.excepthook to log unhandled exceptions."""
+    log = logging.getLogger('watchmaker')
+    log.error('%s', str(exc_value))
+    log.debug(
+        '',
+        exc_info=(exc_type, exc_value, exc_traceback)
+    )
+
+
 def prepare_logging(log_dir, log_level):
     """
     Prepare the logger for handling messages to a file and/or to stdout.


### PR DESCRIPTION
Previously, unhandled exceptions were output only to stderr and were not captured by the logger to the log file. This patch modifies the `sys.excepthook` callable to log the exception properly. The exception message is logged at the error level, and the traceback is logged at the debug level.

While researching and testing this approach, I found that a traceback within a thread still would not be handled with this approach. There were a handful of seemingly difficult and annoying methods to get the traceback to propagate to the parent, but it turns out that `concurrent.futures` makes it quite easy and is backported to py2.6 via the `futures` library. So this patch also modifies the `call_process` method to use `concurrent.futures` instead of `threading`. Futures also can return a value easily, so the queue is no longer necessary either.