### PR TITLE
Modifies CLI logging behavior for most typical expected use case

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -177,7 +177,7 @@ specify something like this for EC2 userdata:
         .
 
     # Run watchmaker
-    watchmaker -vv --log-dir=/var/log/watchmaker
+    watchmaker --log-level debug --log-dir=/var/log/watchmaker
     ```
 
 *   **For Windows**: Modify `GitRepo` and `GitBranch` to reflect working
@@ -228,7 +228,7 @@ specify something like this for EC2 userdata:
         .
 
     # Run watchmaker
-    watchmaker -vv --log-dir=C:\Watchmaker\Logs
+    watchmaker --log-level debug --log-dir=C:\Watchmaker\Logs
     </powershell>
     ```
 

--- a/docs/files/cfn/templates/watchmaker-lx-autoscale.template
+++ b/docs/files/cfn/templates/watchmaker-lx-autoscale.template
@@ -681,7 +681,7 @@
                             {
                                 "command" :
                                 { "Fn::Join" : [ "", [
-                                    "watchmaker -vv",
+                                    "watchmaker --log-level debug",
                                     " --log-dir /var/log/watchmaker",
                                     " --noreboot",
                                     {
@@ -744,7 +744,7 @@
                             {
                                 "command" :
                                 { "Fn::Join" : [ "", [
-                                    "watchmaker -vv",
+                                    "watchmaker --log-level debug",
                                     " --log-dir /var/log/watchmaker",
                                     " --saltstates None",
                                     " --noreboot",

--- a/docs/files/cfn/templates/watchmaker-lx-instance.template
+++ b/docs/files/cfn/templates/watchmaker-lx-instance.template
@@ -626,7 +626,7 @@
                             {
                                 "command" :
                                 { "Fn::Join" : [ "", [
-                                    "watchmaker -vv",
+                                    "watchmaker --log-level debug",
                                     " --log-dir /var/log/watchmaker",
                                     " --noreboot",
                                     {
@@ -701,7 +701,7 @@
                             {
                                 "command" :
                                 { "Fn::Join" : [ "", [
-                                    "watchmaker -vv",
+                                    "watchmaker --log-level debug",
                                     " --log-dir /var/log/watchmaker",
                                     " --saltstates None",
                                     " --noreboot",

--- a/docs/files/cfn/templates/watchmaker-win-autoscale.template
+++ b/docs/files/cfn/templates/watchmaker-win-autoscale.template
@@ -626,7 +626,7 @@
                                     },
                                     " \"& {",
                                     " c:\\cfn\\scripts\\watchmaker-install.ps1;",
-                                    " watchmaker -vv",
+                                    " watchmaker --log-level debug",
                                     " --log-dir C:\\Watchmaker\\Logs",
                                     " --no-reboot",
                                     {
@@ -699,7 +699,7 @@
                                     },
                                     " \"& {",
                                     " c:\\cfn\\scripts\\watchmaker-install.ps1;",
-                                    " watchmaker -vv",
+                                    " watchmaker --log-level debug",
                                     " --log-dir C:\\Watchmaker\\Logs",
                                     " --salt-states None",
                                     " --no-reboot",

--- a/docs/files/cfn/templates/watchmaker-win-instance.template
+++ b/docs/files/cfn/templates/watchmaker-win-instance.template
@@ -571,7 +571,7 @@
                                     },
                                     " \"& {",
                                     " c:\\cfn\\scripts\\watchmaker-install.ps1;",
-                                    " watchmaker -vv",
+                                    " watchmaker --log-level debug",
                                     " --log-dir C:\\Watchmaker\\Logs",
                                     " --no-reboot",
                                     {
@@ -656,7 +656,7 @@
                                     },
                                     " \"& {",
                                     " c:\\cfn\\scripts\\watchmaker-install.ps1;",
-                                    " watchmaker -vv",
+                                    " watchmaker --log-level debug",
                                     " --log-dir C:\\Watchmaker\\Logs",
                                     " --salt-states None",
                                     " --no-reboot",

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,31 +9,35 @@ the output of `watchmaker --help`, showing the CLI options.
 
 ```shell
 # watchmaker --help
-usage: watchmaker [-h] [--version] [-v] [-c CONFIG] [-n] [-l LOG_DIR]
-                  [--s3-source] [-s SALT_STATES] [-A ADMIN_GROUPS]
+usage: watchmaker [-h] [-v] [-c CONFIG_PATH] [-l LOG_LEVEL] [-d LOG_DIR] [-n]
+                  [-s SALT_STATES] [--s3-source] [-A ADMIN_GROUPS]
                   [-a ADMIN_USERS] [-t COMPUTER_NAME] [-e ENVIRONMENT]
                   [-p OU_PATH]
 
 optional arguments:
   -h, --help            show this help message and exit
-  --version             Print version info.
-  -v, --verbose         Enable verbose logging: -v for INFO, -vv to include
-                        DEBUG, if option is left out, only WARNINGS and higher
-                        are logged.
-  -c CONFIG, --config CONFIG
+  -v, -V, --version     Print version info.
+  -c CONFIG_PATH, --config CONFIG_PATH
                         Path or URL to the config.yaml file.
+  -l LOG_LEVEL, --log-level LOG_LEVEL
+                        Set the log level. Case-insensitive. Valid values
+                        include: "critical", "error", "warning", "info", and
+                        "debug".
+  -d LOG_DIR, --log-dir LOG_DIR
+                        Path to the directory where Watchmaker log files will
+                        be saved.
   -n, --no-reboot       If this flag is not passed, Watchmaker will reboot the
                         system upon success. This flag suppresses that
                         behavior. Watchmaker suppresses the reboot
-                        automatically if it encounters afailure.
-  -l LOG_DIR, --log-dir LOG_DIR
-                        Path to the log directory for logging.
-  --s3-source           Use S3 utilities to retrieve content instead of http/s
-                        utilities.
+                        automatically if it encounters a failure.
   -s SALT_STATES, --salt-states SALT_STATES
                         Comma-separated string of salt states to apply. A
                         value of 'None' will not apply any salt states. A
                         value of 'Highstate' will apply the salt highstate.
+  --s3-source           Use S3 utilities to retrieve content instead of http/s
+                        utilities. Boto3 must be installed, and boto3
+                        credentials must be configured that allow access to
+                        the S3 bucket.
   -A ADMIN_GROUPS, --admin-groups ADMIN_GROUPS
                         Set a salt grain that specifies the domain groups that
                         should have root privileges on Linux or admin
@@ -96,7 +100,7 @@ yum -y --enablerepo=epel install python-pip
 pip install --index-url="$PYPI_URL" --trusted-host="$PYPI_HOST" --allow-all-external --upgrade pip setuptools watchmaker
 
 # Run watchmaker
-watchmaker -vv --log-dir=/var/log/watchmaker
+watchmaker --log-level debug --log-dir=/var/log/watchmaker
 ```
 
 Alternatively, cloud-config directives can also be used on **Linux**:
@@ -118,7 +122,7 @@ runcmd:
     pip install --index-url="$PYPI_URL" --trusted-host="$PYPI_HOST" --allow-all-external --upgrade pip setuptools watchmaker
 
     # Run watchmaker
-    watchmaker -vv --log-dir=/var/log/watchmaker
+    watchmaker --log-level debug --log-dir=/var/log/watchmaker
 ```
 
 ### Windows
@@ -147,7 +151,7 @@ $BootstrapFile = "${Env:Temp}\$(${BootstrapUrl}.split('/')[-1])"
 pip install --index-url="$PypiUrl" --trusted-host="$PypiHost" --upgrade pip setuptools watchmaker
 
 # Run watchmaker
-watchmaker -vv --log-dir=C:\Watchmaker\Logs
+watchmaker --log-level debug --log-dir=C:\Watchmaker\Logs
 </powershell>
 ```
 

--- a/src/watchmaker/cli.py
+++ b/src/watchmaker/cli.py
@@ -31,27 +31,18 @@ def main():
     version_string = 'watchmaker v{0}'.format(watchmaker.__version__)
 
     parser = argparse.ArgumentParser()
-    parser.add_argument('-V', '--version', action='version',
+    parser.add_argument('-v', '-V', '--version', action='version',
                         version=version_string, help='Print version info.')
-    parser.add_argument('-v', '--verbose', dest='verbosity',
+    parser.add_argument('-c', '--config', dest='config_path', default=None,
+                        help='Path or URL to the config.yaml file.')
+    parser.add_argument('-l', '--log-level', dest='log_level',
                         default='debug',
                         help=(
                             'Set the log level. Case-insensitive. Valid '
                             'values include: "critical", "error", "warning", '
                             '"info", and "debug".'
                         ))
-    parser.add_argument('-c', '--config', dest='config_path', default=None,
-                        help='Path or URL to the config.yaml file.')
-    parser.add_argument('-n', '--no-reboot', dest='no_reboot',
-                        action='store_true',
-                        help=(
-                            'If this flag is not passed, Watchmaker will '
-                            'reboot the system upon success. This flag '
-                            'suppresses that behavior. Watchmaker suppresses '
-                            'the reboot automatically if it encounters a '
-                            'failure.'
-                        ))
-    parser.add_argument('-l', '--log-dir', dest='log_dir',
+    parser.add_argument('-d', '--log-dir', dest='log_dir',
                         default=LOG_LOCATIONS.get(
                             platform.system().lower(),
                             None
@@ -61,13 +52,14 @@ def main():
                             'Path to the directory where Watchmaker log files '
                             'will be saved.'
                         ))
-    parser.add_argument('--s3-source', dest='s3_source',
-                        action='store_const', const=True, default=None,
+    parser.add_argument('-n', '--no-reboot', dest='no_reboot',
+                        action='store_true',
                         help=(
-                            'Use S3 utilities to retrieve content instead of '
-                            'http/s utilities. Boto3 must be installed, and '
-                            'boto3 credentials must be configured that allow '
-                            'access to the S3 bucket.'
+                            'If this flag is not passed, Watchmaker will '
+                            'reboot the system upon success. This flag '
+                            'suppresses that behavior. Watchmaker suppresses '
+                            'the reboot automatically if it encounters a '
+                            'failure.'
                         ))
     parser.add_argument('-s', '--salt-states', dest='salt_states',
                         default=None,
@@ -76,6 +68,14 @@ def main():
                             'A value of \'None\' will not apply any salt '
                             'states. A value of \'Highstate\' will apply the '
                             'salt highstate.'
+                        ))
+    parser.add_argument('--s3-source', dest='s3_source',
+                        action='store_const', const=True, default=None,
+                        help=(
+                            'Use S3 utilities to retrieve content instead of '
+                            'http/s utilities. Boto3 must be installed, and '
+                            'boto3 credentials must be configured that allow '
+                            'access to the S3 bucket.'
                         ))
     parser.add_argument('-A', '--admin-groups', dest='admin_groups',
                         default=None,
@@ -114,7 +114,7 @@ def main():
                         ))
 
     arguments, extra_arguments = parser.parse_known_args()
-    prepare_logging(arguments.log_dir, arguments.verbosity)
+    prepare_logging(arguments.log_dir, arguments.log_level)
 
     # Setup excepthook to log all unhandled exceptions
     sys.excepthook = exception_hook

--- a/src/watchmaker/cli.py
+++ b/src/watchmaker/cli.py
@@ -33,12 +33,12 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-V', '--version', action='version',
                         version=version_string, help='Print version info.')
-    parser.add_argument('-v', '--verbose', action='count', dest='verbosity',
-                        default=0,
+    parser.add_argument('-v', '--verbose', dest='verbosity',
+                        default='debug',
                         help=(
-                            'Enable verbose logging: -v for INFO, -vv to '
-                            'include DEBUG. If not specified, the default is '
-                            'to log only WARNINGS and higher.'
+                            'Set the log level. Case-insensitive. Valid '
+                            'values include: "critical", "error", "warning", '
+                            '"info", and "debug".'
                         ))
     parser.add_argument('-c', '--config', dest='config_path', default=None,
                         help='Path or URL to the config.yaml file.')
@@ -48,7 +48,7 @@ def main():
                             'If this flag is not passed, Watchmaker will '
                             'reboot the system upon success. This flag '
                             'suppresses that behavior. Watchmaker suppresses '
-                            'the reboot automatically if it encounters a'
+                            'the reboot automatically if it encounters a '
                             'failure.'
                         ))
     parser.add_argument('-l', '--log-dir', dest='log_dir',

--- a/src/watchmaker/cli.py
+++ b/src/watchmaker/cli.py
@@ -5,10 +5,17 @@ from __future__ import (absolute_import, division, print_function,
 
 import argparse
 import os
+import platform
 import sys
 
 import watchmaker
 from watchmaker.logger import exception_hook, prepare_logging
+
+LOG_LOCATIONS = {
+    'linux': os.path.sep.join(('', 'var', 'log', 'watchmaker')),
+    'windows': os.path.sep.join((
+        os.environ.get('SYSTEMDRIVE', 'C:'), 'Watchmaker', 'Logs'))
+}
 
 
 def _validate_log_dir(log_dir):
@@ -44,7 +51,11 @@ def main():
                             'the reboot automatically if it encounters a'
                             'failure.'
                         ))
-    parser.add_argument('-l', '--log-dir', dest='log_dir', default=None,
+    parser.add_argument('-l', '--log-dir', dest='log_dir',
+                        default=LOG_LOCATIONS.get(
+                            platform.system().lower(),
+                            None
+                        ),
                         type=_validate_log_dir,
                         help=(
                             'Path to the directory where Watchmaker log files '

--- a/src/watchmaker/logger/__init__.py
+++ b/src/watchmaker/logger/__init__.py
@@ -10,8 +10,11 @@ import os
 LOG_LEVELS = collections.defaultdict(
     lambda: logging.DEBUG,  # log level if key is not in this dict
     {
-        0: logging.WARNING,
-        1: logging.INFO
+        'critical': logging.CRITICAL,
+        'error': logging.ERROR,
+        'warning': logging.WARNING,
+        'info': logging.INFO,
+        'debug': logging.DEBUG
     }
 )
 
@@ -39,20 +42,20 @@ def prepare_logging(log_dir, log_level):
             this argument evaluates to ``False``, then logging to a file is
             disabled. Watchmaker will always output to stdout/stderr.
 
-        log_level: (:obj:`int`)
-            Level to log at. Any value other than the integers below will
-            enable DEBUG logging.
+        log_level: (:obj:`str`)
+            Level to log at. Case-insensitive. Valid options include,
+            from least to most verbose:
 
-            .. code-block:: python
-
-                0: WARNING
-                1: INFO
-                *: DEBUG
+            - ``critical``
+            - ``error``
+            - ``warning``
+            - ``info``
+            - ``debug``
     """
     logformat = (
         '%(asctime)s [%(name)s][%(levelname)-5s][%(process)s]: %(message)s'
     )
-    level = LOG_LEVELS[log_level]
+    level = LOG_LEVELS[str(log_level).lower()]
 
     logging.basicConfig(format=logformat, level=level)
 


### PR DESCRIPTION
When called from the CLI, this patch enables debug logging and sets the log-dir to a platform-specific default location.

The CLI arguments have also been adjusted slightly to accommodate this change:

* Uses `-l|--log-level` instead of `-v|--verbose`
* `-v` and `-V` are now both used for `--version`
* `-d` is now used for `--log-dir`