### PR TITLE
Modifies boto3 dynamic import to use only absolute imports

### DIFF
--- a/src/watchmaker/managers/base.py
+++ b/src/watchmaker/managers/base.py
@@ -73,7 +73,7 @@ class ManagerBase(object):
                 globals(),
                 locals(),
                 ["ClientError"],
-                -1
+                0
             )
         except ImportError:
             msg = 'Unable to import boto3 module.'


### PR DESCRIPTION
Negative "level" values stopped being supported as of py3.3. A
value of 0 means that the import is absolute (which it is).