### PR TITLE
Uses click for cli argument processing

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,57 +9,51 @@ the output of `watchmaker --help`, showing the CLI options.
 
 ```shell
 # watchmaker --help
-usage: watchmaker [-h] [-v] [-c CONFIG_PATH] [-l LOG_LEVEL] [-d LOG_DIR] [-n]
-                  [-s SALT_STATES] [--s3-source] [-A ADMIN_GROUPS]
-                  [-a ADMIN_USERS] [-t COMPUTER_NAME] [-e ENVIRONMENT]
-                  [-p OU_PATH]
+Usage: watchmaker [OPTIONS]
 
-optional arguments:
-  -h, --help            show this help message and exit
-  -v, -V, --version     Print version info.
-  -c CONFIG_PATH, --config CONFIG_PATH
-                        Path or URL to the config.yaml file.
-  -l LOG_LEVEL, --log-level LOG_LEVEL
-                        Set the log level. Case-insensitive. Valid values
-                        include: "critical", "error", "warning", "info", and
-                        "debug".
-  -d LOG_DIR, --log-dir LOG_DIR
-                        Path to the directory where Watchmaker log files will
-                        be saved.
-  -n, --no-reboot       If this flag is not passed, Watchmaker will reboot the
-                        system upon success. This flag suppresses that
-                        behavior. Watchmaker suppresses the reboot
-                        automatically if it encounters a failure.
-  -s SALT_STATES, --salt-states SALT_STATES
-                        Comma-separated string of salt states to apply. A
-                        value of 'None' will not apply any salt states. A
-                        value of 'Highstate' will apply the salt highstate.
-  --s3-source           Use S3 utilities to retrieve content instead of http/s
-                        utilities. Boto3 must be installed, and boto3
-                        credentials must be configured that allow access to
-                        the S3 bucket.
-  -A ADMIN_GROUPS, --admin-groups ADMIN_GROUPS
-                        Set a salt grain that specifies the domain groups that
-                        should have root privileges on Linux or admin
-                        privileges on Windows. Value must be a colon-separated
-                        string. E.g. "group1:group2"
-  -a ADMIN_USERS, --admin-users ADMIN_USERS
-                        Set a salt grain that specifies the domain users that
-                        should have root privileges on Linux or admin
-                        privileges on Windows. Value must be a colon-separated
-                        string. E.g. "user1:user2"
-  -t COMPUTER_NAME, --computer-name COMPUTER_NAME
-                        Set a salt grain that specifies the computername to
-                        apply to the system.
-  -e ENVIRONMENT, --env ENVIRONMENT
-                        Set a salt grain that specifies the environment in
-                        which the system is being built. E.g. dev, test, or
-                        prod
-  -p OU_PATH, --ou-path OU_PATH
-                        Set a salt grain that specifies the full DN of the OU
-                        where the computer account will be created when
-                        joining a domain. E.g.
-                        "OU=SuperCoolApp,DC=example,DC=com"
+  Entry point for Watchmaker cli.
+
+Options:
+  --version                       Show the version and exit.
+  -c, --config TEXT               Path or URL to the config.yaml file.
+  -l, --log-level [info|debug|critical|warning|error]
+                                  Set the log level. Case-insensitive.
+  -d, --log-dir DIRECTORY         Path to the directory where Watchmaker log
+                                  files will be saved.
+  -n, --no-reboot                 If this flag is not passed, Watchmaker will
+                                  reboot the system upon success. This flag
+                                  suppresses that behavior. Watchmaker
+                                  suppresses the reboot automatically if it
+                                  encounters a failure.
+  -s, --salt-states TEXT          Comma-separated string of salt states to
+                                  apply. A value of 'None' will not apply any
+                                  salt states. A value of 'Highstate' will
+                                  apply the salt highstate.
+  --s3-source                     Use S3 utilities to retrieve content instead
+                                  of http/s utilities. Boto3 must be
+                                  installed, and boto3 credentials must be
+                                  configured that allow access to the S3
+                                  bucket.
+  -A, --admin-groups TEXT         Set a salt grain that specifies the domain
+                                  groups that should have root privileges on
+                                  Linux or admin privileges on Windows. Value
+                                  must be a colon-separated string. E.g.
+                                  "group1:group2"
+  -a, --admin-users TEXT          Set a salt grain that specifies the domain
+                                  users that should have root privileges on
+                                  Linux or admin privileges on Windows. Value
+                                  must be a colon-separated string. E.g.
+                                  "user1:user2"
+  -t, --computer-name TEXT        Set a salt grain that specifies the
+                                  computername to apply to the system.
+  -e, --env TEXT                  Set a salt grain that specifies the
+                                  environment in which the system is being
+                                  built. E.g. dev, test, or prod
+  -p, --ou-path TEXT              Set a salt grain that specifies the full DN
+                                  of the OU where the computer account will be
+                                  created when joining a domain. E.g.
+                                  "OU=SuperCoolApp,DC=example,DC=com"
+  --help                          Show this message and exit.
 ```
 
 ## `watchmaker` as EC2 userdata

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
         ]
     },
     install_requires=[
-        "argparse",
+        "click",
         "futures",
         "six",
         "PyYAML",

--- a/src/watchmaker/__init__.py
+++ b/src/watchmaker/__init__.py
@@ -167,7 +167,7 @@ class Arguments(dict):
         self.salt_states = kwargs.pop('salt_states', None)
         self.s3_source = kwargs.pop('s3_source', None)
         self.ou_path = kwargs.pop('ou_path', None)
-        self.extra_arguments = kwargs.pop('extra_arguments', [])
+        self.extra_arguments = kwargs.pop('extra_arguments', None) or []
 
     def __getattr__(self, attr):
         """Support attr-notation for getting dict contents."""

--- a/src/watchmaker/__init__.py
+++ b/src/watchmaker/__init__.py
@@ -50,16 +50,15 @@ class Arguments(dict):
             automatically suppresses the reboot if it encounters an error.
             (*Default*: ``False``)
 
-        verbosity: (:obj:`int`)
-            Level to log at. Any value other than the integers below will
-            enable DEBUG logging.
-            (*Default*: ``0``)
+        log_level: (:obj:`str`)
+            Level to log at. Case-insensitive. Valid options include,
+            from least to most verbose:
 
-            .. code-block:: python
-
-                0: WARNING
-                1: INFO
-                *: DEBUG
+            - ``critical``
+            - ``error``
+            - ``warning``
+            - ``info``
+            - ``debug``
 
     .. important::
 
@@ -151,7 +150,7 @@ class Arguments(dict):
         config_path=None,
         log_dir=None,
         no_reboot=False,
-        verbosity=0,
+        log_level=None,
         *args,
         **kwargs
     ):
@@ -159,7 +158,7 @@ class Arguments(dict):
         self.config_path = config_path
         self.log_dir = log_dir
         self.no_reboot = no_reboot
-        self.verbosity = verbosity
+        self.log_level = log_level
         self.admin_groups = kwargs.pop('admin_groups', None)
         self.admin_users = kwargs.pop('admin_users', None)
         self.computer_name = kwargs.pop('computer_name', None)
@@ -205,7 +204,7 @@ class Client(object):
         self.no_reboot = arguments.pop('no_reboot', False)
         self.config_path = arguments.pop('config_path')
         self.log_dir = arguments.pop('log_dir')
-        self.verbosity = arguments.pop('verbosity')
+        self.log_level = arguments.pop('log_level')
 
         # Get the system params
         self.system = platform.system().lower()

--- a/src/watchmaker/cli.py
+++ b/src/watchmaker/cli.py
@@ -3,13 +3,16 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals, with_statement)
 
-import argparse
 import os
 import platform
 import sys
 
+import click
+
 import watchmaker
-from watchmaker.logger import exception_hook, prepare_logging
+from watchmaker.logger import LOG_LEVELS, exception_hook, prepare_logging
+
+click.disable_unicode_literals_warning = True
 
 LOG_LOCATIONS = {
     'linux': os.path.sep.join(('', 'var', 'log', 'watchmaker')),
@@ -18,110 +21,73 @@ LOG_LOCATIONS = {
 }
 
 
-def _validate_log_dir(log_dir):
-    if os.path.isfile(log_dir):
-        raise argparse.ArgumentTypeError(
-            '"{0}" exists as a file.'.format(log_dir)
-        )
-    return log_dir
-
-
-def main():
+@click.command(context_settings=dict(
+    ignore_unknown_options=True,
+))
+@click.version_option(version=watchmaker.__version__)
+@click.option('-c', '--config', 'config_path', default=None,
+              help='Path or URL to the config.yaml file.')
+@click.option('-l', '--log-level', default='debug',
+              type=click.Choice(list(LOG_LEVELS.keys())),
+              help='Set the log level. Case-insensitive.')
+@click.option('-d', '--log-dir',
+              type=click.Path(exists=False, file_okay=False),
+              default=LOG_LOCATIONS.get(platform.system().lower(), None),
+              help=(
+                  'Path to the directory where Watchmaker log files will be '
+                  'saved.'))
+@click.option('-n', '--no-reboot', 'no_reboot', flag_value=True, default=False,
+              help=(
+                  'If this flag is not passed, Watchmaker will reboot the '
+                  'system upon success. This flag suppresses that behavior. '
+                  'Watchmaker suppresses the reboot automatically if it '
+                  'encounters a failure.'))
+@click.option('-s', '--salt-states', default=None,
+              help=(
+                  'Comma-separated string of salt states to apply. A value of '
+                  '\'None\' will not apply any salt states. A value of '
+                  '\'Highstate\' will apply the salt highstate.'))
+@click.option('--s3-source', 's3_source', flag_value=True, default=None,
+              help=(
+                  'Use S3 utilities to retrieve content instead of http/s '
+                  'utilities. Boto3 must be installed, and boto3 credentials '
+                  'must be configured that allow access to the S3 bucket.'))
+@click.option('-A', '--admin-groups', default=None,
+              help=(
+                  'Set a salt grain that specifies the domain groups that '
+                  'should have root privileges on Linux or admin privileges '
+                  'on Windows. Value must be a colon-separated string. E.g. '
+                  '"group1:group2"'))
+@click.option('-a', '--admin-users', default=None,
+              help=(
+                  'Set a salt grain that specifies the domain users that '
+                  'should have root privileges on Linux or admin privileges '
+                  'on Windows. Value must be a colon-separated string. E.g. '
+                  '"user1:user2"'))
+@click.option('-t', '--computer-name', default=None,
+              help=(
+                  'Set a salt grain that specifies the computername to apply '
+                  'to the system.'))
+@click.option('-e', '--env', 'environment', default=None,
+              help=(
+                  'Set a salt grain that specifies the environment in which '
+                  'the system is being built. E.g. dev, test, or prod'))
+@click.option('-p', '--ou-path', default=None,
+              help=(
+                  'Set a salt grain that specifies the full DN of the OU '
+                  'where the computer account will be created when joining a '
+                  'domain. E.g. "OU=SuperCoolApp,DC=example,DC=com"'))
+@click.argument('extra_arguments', nargs=-1, type=click.UNPROCESSED,
+                metavar='')
+def main(extra_arguments=None, **kwargs):
     """Entry point for Watchmaker cli."""
-    version_string = 'watchmaker v{0}'.format(watchmaker.__version__)
+    prepare_logging(kwargs['log_dir'], kwargs['log_level'])
 
-    parser = argparse.ArgumentParser()
-    parser.add_argument('-v', '-V', '--version', action='version',
-                        version=version_string, help='Print version info.')
-    parser.add_argument('-c', '--config', dest='config_path', default=None,
-                        help='Path or URL to the config.yaml file.')
-    parser.add_argument('-l', '--log-level', dest='log_level',
-                        default='debug',
-                        help=(
-                            'Set the log level. Case-insensitive. Valid '
-                            'values include: "critical", "error", "warning", '
-                            '"info", and "debug".'
-                        ))
-    parser.add_argument('-d', '--log-dir', dest='log_dir',
-                        default=LOG_LOCATIONS.get(
-                            platform.system().lower(),
-                            None
-                        ),
-                        type=_validate_log_dir,
-                        help=(
-                            'Path to the directory where Watchmaker log files '
-                            'will be saved.'
-                        ))
-    parser.add_argument('-n', '--no-reboot', dest='no_reboot',
-                        action='store_true',
-                        help=(
-                            'If this flag is not passed, Watchmaker will '
-                            'reboot the system upon success. This flag '
-                            'suppresses that behavior. Watchmaker suppresses '
-                            'the reboot automatically if it encounters a '
-                            'failure.'
-                        ))
-    parser.add_argument('-s', '--salt-states', dest='salt_states',
-                        default=None,
-                        help=(
-                            'Comma-separated string of salt states to apply. '
-                            'A value of \'None\' will not apply any salt '
-                            'states. A value of \'Highstate\' will apply the '
-                            'salt highstate.'
-                        ))
-    parser.add_argument('--s3-source', dest='s3_source',
-                        action='store_const', const=True, default=None,
-                        help=(
-                            'Use S3 utilities to retrieve content instead of '
-                            'http/s utilities. Boto3 must be installed, and '
-                            'boto3 credentials must be configured that allow '
-                            'access to the S3 bucket.'
-                        ))
-    parser.add_argument('-A', '--admin-groups', dest='admin_groups',
-                        default=None,
-                        help=(
-                            'Set a salt grain that specifies the domain '
-                            'groups that should have root privileges on Linux '
-                            'or admin privileges on Windows. Value must be a '
-                            'colon-separated string. E.g. "group1:group2"'
-                        ))
-    parser.add_argument('-a', '--admin-users', dest='admin_users',
-                        default=None,
-                        help=(
-                            'Set a salt grain that specifies the domain users '
-                            'that should have root privileges on Linux or '
-                            'admin privileges on Windows. Value must be a '
-                            'colon-separated string. E.g. "user1:user2"'
-                        ))
-    parser.add_argument('-t', '--computer-name', dest='computer_name',
-                        default=None,
-                        help=(
-                            'Set a salt grain that specifies the computername '
-                            'to apply to the system.'
-                        ))
-    parser.add_argument('-e', '--env', dest='environment', default=None,
-                        help=(
-                            'Set a salt grain that specifies the environment '
-                            'in which the system is being built. E.g. dev, '
-                            'test, or prod'
-                        ))
-    parser.add_argument('-p', '--ou-path', dest='ou_path', default=None,
-                        help=(
-                            'Set a salt grain that specifies the full DN of '
-                            'the OU where the computer account will be '
-                            'created when joining a domain. E.g. '
-                            '"OU=SuperCoolApp,DC=example,DC=com"'
-                        ))
-
-    arguments, extra_arguments = parser.parse_known_args()
-    prepare_logging(arguments.log_dir, arguments.log_level)
-
-    # Setup excepthook to log all unhandled exceptions
     sys.excepthook = exception_hook
 
     watchmaker_arguments = watchmaker.Arguments(**dict(
         extra_arguments=extra_arguments,
-        **vars(arguments)
+        **kwargs
     ))
     watchmaker_client = watchmaker.Client(watchmaker_arguments)
     sys.exit(watchmaker_client.install())


### PR DESCRIPTION
Replaces argparse. The argparse library dependency was required to
use argparse on py26, but the libary is not actively maintained.
Argparse is actively maintained as a core python library, but only
available in py27 and later. Installing argparse from pypi can
result in some odd behavior on imports, as we may get the core
library _or_ the pypi library (depending on platform, typically).

Using click ensures consistent behavior across all platforms and
python versions.

I looked at `invoke` also, but couldn't figure out how to replicate some of our option types, and felt the docs weren't quite as mature as `click`. This implementation with `click` results in identical cli usage as the prior approach with `argparse`.