### PR TITLE
Includes failed state output in exception message

### DIFF
--- a/src/watchmaker/logger/__init__.py
+++ b/src/watchmaker/logger/__init__.py
@@ -22,8 +22,7 @@ LOG_LEVELS = collections.defaultdict(
 def exception_hook(exc_type, exc_value, exc_traceback):
     """Log unhandled exceptions with hook for sys.excepthook."""
     log = logging.getLogger('watchmaker')
-    log.error('%s', str(exc_value))
-    log.debug(
+    log.critical(
         '',
         exc_info=(exc_type, exc_value, exc_traceback)
     )

--- a/src/watchmaker/managers/base.py
+++ b/src/watchmaker/managers/base.py
@@ -210,19 +210,18 @@ class ManagerBase(object):
         return working_dir
 
     @staticmethod
-    def _pipe_logger(pipe, logger, prefix_msg='', return_output=False):
+    def _pipe_logger(pipe, logger, prefix_msg=''):
         ret = b''
         try:
             for line in iter(pipe.readline, b''):
                 logger('%s%s', prefix_msg, line.rstrip())
-                if return_output:
-                    ret = ret + line
+                ret += line
         finally:
             pipe.close()
 
-        return ret or None
+        return ret
 
-    def call_process(self, cmd, stdout=False, raise_error=True):
+    def call_process(self, cmd, raise_error=True):
         """
         Execute a shell command.
 
@@ -230,31 +229,29 @@ class ManagerBase(object):
             cmd: (:obj:`list`)
                 Command to execute.
 
-            stdout: (:obj:`bool`)
-                Switch to control whether to return stdout.
-                (*Default*: ``False``)
-
             raise_error: (:obj:`bool`)
                 Switch to control whether to raise if the command return code
                 is non-zero.
                 (*Default*: ``True``)
 
         Returns:
-            :obj:`None` or :obj:`bytes`:
-                ``None`` unless ``stdout`` is ``True``. In that case, the
-                stdout is returned as a bytes object.
+            :obj:`dict`:
+                Dictionary containing three keys: ``retcode`` (:obj:`int`),
+                ``stdout`` (:obj:`bytes`), and ``stderr`` (:obj:`bytes`).
 
         """
-        ret = None
-        stdout_ret = b''
-        stderr_ret = b''  # pylint: disable=unused-variable
+        ret = {
+            'retcode': 0,
+            'stdout': b'',
+            'stderr': b''
+        }
 
         if not isinstance(cmd, list):
             msg = 'Command is not a list: {0}'.format(cmd)
             self.log.critical(msg)
             raise WatchmakerException(msg)
 
-        self.log.debug('Running command: %s', cmd)
+        self.log.debug('Command: %s', ' '.join(cmd))
         process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE,
@@ -266,8 +263,8 @@ class ManagerBase(object):
                 self._pipe_logger,
                 process.stdout,
                 self.log.debug,
-                'Command stdout: ',
-                stdout)
+                'Command stdout: '
+            )
 
             stderr_future = executor.submit(
                 self._pipe_logger,
@@ -275,20 +272,18 @@ class ManagerBase(object):
                 self.log.error,
                 'Command stderr: ')
 
-            stdout_ret = stdout_future.result()
-            stderr_ret = stderr_future.result()  # noqa: F841,E501  # pylint: disable=unused-variable
+            ret['stdout'] = stdout_future.result()
+            ret['stderr'] = stderr_future.result()
 
-        returncode = process.wait()
+        ret['retcode'] = process.wait()
 
-        if raise_error and returncode != 0:
+        self.log.debug('Command retcode: %s', ret['retcode'])
+
+        if raise_error and ret['retcode'] != 0:
             msg = 'Command failed! Exit code={0}, cmd={1}'.format(
-                process.returncode, cmd)
+                ret['retcode'], ' '.join(cmd))
             self.log.critical(msg)
             raise WatchmakerException(msg)
-
-        if stdout:
-            # Return stdout
-            ret = stdout_ret
 
         return ret
 

--- a/src/watchmaker/managers/base.py
+++ b/src/watchmaker/managers/base.py
@@ -222,7 +222,7 @@ class ManagerBase(object):
 
         return ret or None
 
-    def call_process(self, cmd, stdout=False):
+    def call_process(self, cmd, stdout=False, raise_error=True):
         """
         Execute a shell command.
 
@@ -233,6 +233,11 @@ class ManagerBase(object):
             stdout: (:obj:`bool`)
                 Switch to control whether to return stdout.
                 (*Default*: ``False``)
+
+            raise_error: (:obj:`bool`)
+                Switch to control whether to raise if the command return code
+                is non-zero.
+                (*Default*: ``True``)
 
         Returns:
             :obj:`None` or :obj:`bytes`:
@@ -275,7 +280,7 @@ class ManagerBase(object):
 
         returncode = process.wait()
 
-        if returncode != 0:
+        if raise_error and returncode != 0:
             msg = 'Command failed! Exit code={0}, cmd={1}'.format(
                 process.returncode, cmd)
             self.log.critical(msg)

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -440,7 +440,7 @@ class SaltBase(ManagerBase):
                 )
                 cmd.extend(['state.sls', states])
 
-            ret = self.run_salt(cmd, raise_error=False)
+            ret = self.run_salt(cmd, log_pipe='stderr', raise_error=False)
 
             if ret['retcode'] != 0:
                 failed_states = self._get_failed_states(

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -420,25 +420,23 @@ class SaltBase(ManagerBase):
             self.log.info(
                 'No States were specified. Will not apply any salt states.'
             )
-        elif states.lower() == 'highstate':
-            self.log.info(
-                'Detected the `states` parameter is set to `highstate`. '
-                'Applying the salt "highstate" to the system.'
-            )
-            cmd = ['state.highstate']
-            cmd.extend(self.salt_call_args)
-            self.run_salt(cmd)
         else:
-            self.log.info(
-                'Detected the `states` parameter is set to: `%s`. Applying '
-                'the user-defined list of states to the system.',
-                states
-            )
-            cmd = ['state.sls', states]
-            cmd.extend(self.salt_call_args)
-            self.run_salt(cmd)
+            cmd = [self.salt_call_args]
+            if states.lower() == 'highstate':
+                self.log.info(
+                    'Applying the salt "highstate", states=%s',
+                    states
+                )
+                cmd.extend(['state.highstate'])
+            else:
+                self.log.info(
+                    'Applying the user-defined list of states, states=%s',
+                    states
+                )
+                cmd.extend(['state.sls', states])
 
-        self.log.info('Salt states all applied successfully!')
+            ret = self.run_salt(cmd, stdout=True)
+            self.log.info('Salt states all applied successfully!')
 
 
 class SaltLinux(SaltBase, LinuxManager):

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -107,7 +107,7 @@ class SaltBase(ManagerBase):
         self.salt_call = None
         self.salt_base_env = None
         self.salt_formula_root = None
-        self.salt_call_args = None
+        self.salt_state_args = None
         self.salt_debug_logfile = None
 
     @staticmethod
@@ -135,7 +135,7 @@ class SaltBase(ManagerBase):
                 (self.salt_log_dir, 'salt_call.debug.log')
             )
 
-        self.salt_call_args = [
+        self.salt_state_args = [
             '--log-file', self.salt_debug_logfile,
             '--log-file-level', 'debug',
             '--state-output', 'mixed_id'
@@ -421,7 +421,7 @@ class SaltBase(ManagerBase):
                 'No States were specified. Will not apply any salt states.'
             )
         else:
-            cmd = [self.salt_call_args]
+            cmd = self.salt_state_args
             if states.lower() == 'highstate':
                 self.log.info(
                     'Applying the salt "highstate", states=%s',

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -6,7 +6,6 @@ from __future__ import (absolute_import, division, print_function,
 import codecs
 import json
 import os
-import re
 import shutil
 
 import yaml
@@ -290,8 +289,8 @@ class SaltBase(ManagerBase):
             '--out', 'newline_values_only'
         ]
         return (
-            self.run_salt(cmd_status, stdout=True).strip().lower() == b'true',
-            self.run_salt(cmd_enabled, stdout=True).strip().lower() == b'true'
+            self.run_salt(cmd_status)['stdout'].strip().lower() == b'true',
+            self.run_salt(cmd_enabled)['stdout'].strip().lower() == b'true'
         )
 
     def service_stop(self, service):
@@ -312,8 +311,7 @@ class SaltBase(ManagerBase):
             'service.stop', service,
             '--out', 'newline_values_only'
         ]
-        ret = self.run_salt(cmd, stdout=True)
-        return ret.strip().lower() == b'true'
+        return self.run_salt(cmd)['stdout'].strip().lower() == b'true'
 
     def service_start(self, service):
         """
@@ -333,8 +331,7 @@ class SaltBase(ManagerBase):
             'service.start', service,
             '--out', 'newline_values_only'
         ]
-        ret = self.run_salt(cmd, stdout=True)
-        return ret.strip().lower() == b'true'
+        return self.run_salt(cmd)['stdout'].strip().lower() == b'true'
 
     def service_disable(self, service):
         """
@@ -354,8 +351,7 @@ class SaltBase(ManagerBase):
             'service.disable', service,
             '--out', 'newline_values_only'
         ]
-        ret = self.run_salt(cmd, stdout=True)
-        return ret.strip().lower() == b'true'
+        return self.run_salt(cmd)['stdout'].strip().lower() == b'true'
 
     def service_enable(self, service):
         """
@@ -375,8 +371,7 @@ class SaltBase(ManagerBase):
             'service.enable', service,
             '--out', 'newline_values_only'
         ]
-        ret = self.run_salt(cmd, stdout=True)
-        return ret.strip().lower() == b'true'
+        return self.run_salt(cmd)['stdout'].strip().lower() == b'true'
 
     def process_grains(self):
         """Set salt grains."""
@@ -432,7 +427,7 @@ class SaltBase(ManagerBase):
                 )
                 cmd.extend(['state.sls', states])
 
-            ret = self.run_salt(cmd, stdout=True, raise_error=False)
+            ret = self.run_salt(cmd, raise_error=False)
 
             if ret['retcode'] != 0:
                 raise WatchmakerException(


### PR DESCRIPTION
Previously, the exception message was very generic as it was raise by the manager method, `call_process`, which isn't aware of the context of the call.

This patch moves the raise to the salt worker method, `process_states`, which allows us to be more specific about the error and include more information about the failure. Now, when a state fails, the last messages in the log file will be referencing exactly the states that failed. This _ought_ to result in more accurate issue/bug reports.