### PR TITLE
Fixing issues with `open`.

### DIFF
--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -56,7 +56,7 @@ class Yum(LinuxManager):
 
         # Read first line from /etc/system-release
         try:
-            with open(name='/etc/system-release', mode='rb') as fh_:
+            with open('/etc/system-release', mode='rb') as fh_:
                 release = fh_.readline().strip()
         except Exception:
             self.log.critical(


### PR DESCRIPTION
py2's `open` uses `name` as key for parameter while `py3` uses `file`.  Both expect path to be in first position, so a potential easy fix to just remove the key `name=`.

Fixes issue #322 