### PR TITLE
Removing 'rb' Mode

### DIFF
--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -56,7 +56,7 @@ class Yum(LinuxManager):
 
         # Read first line from /etc/system-release
         try:
-            with open('/etc/system-release', mode='rb') as fh_:
+            with open('/etc/system-release') as fh_:
                 release = fh_.readline().strip()
         except Exception:
             self.log.critical(


### PR DESCRIPTION
Due to the error `TypeError: can't use a string pattern on a bytes-like object`, we remove `mode=rb` from the `open()` method in yum.py and let `open()` open the file in default mode (`r`).