### PR TITLE
Update Grain for Ash_Role

### DIFF
--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -727,7 +727,7 @@ class SaltWindows(SaltBase, WindowsManager):
                 self.log.error('Failed to restart %s service', salt_svc)
 
         if self.ash_role and self.ash_role != 'None':
-            role = {'role': str(self.ash_role)}
+            role = {'lookup': {'role': str(self.ash_role)}}
             self._set_grain('ash-windows', role)
 
         self.process_grains()


### PR DESCRIPTION
Updates the setting of the grain for `ash_role` so it will be picked up by `ash-windows-formula`'s `map.jinja`.

Addresses issue #331.