### PR TITLE
Uses new url for testpypi server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_deploy:
   - python $TRAVIS_BUILD_DIR/ci/travis_set_build.py --skip "$TRAVIS_TAG"
 deploy:
   - provider: pypi
-    server: https://testpypi.python.org/pypi
+    server: https://test.pypi.org/legacy/
     distributions: sdist bdist_wheel
     user: plus3it
     password:


### PR DESCRIPTION
See https://packaging.python.org/guides/migrating-to-pypi-org/#uploading