### PR TITLE
Fix Pip install for FIPS compliance - ASG

### DIFF
--- a/docs/files/cfn/templates/watchmaker-lx-autoscale.template
+++ b/docs/files/cfn/templates/watchmaker-lx-autoscale.template
@@ -1000,7 +1000,7 @@
                         "# Get pip\n",
                         "curl --silent --show-error --retry 5 -L ",
                         { "Ref" : "CfnGetPipUrl" },
-                        " | python", "\n\n",
+                        " | python - --index-url=", { "Ref" : "PypiIndexUrl" }, "\n\n",
 
                         "# Add pip to path\n",
                         "hash pip 2> /dev/null || ",


### PR DESCRIPTION
Altered CFN to match the options used in the documentation: http://watchmaker.readthedocs.io/en/stable/usage.html?highlight=fips#watchmaker-as-ec2-userdata

Launching EL7 SPEL will fail without FIPS compliance

RE: https://github.com/plus3it/watchmaker/pull/358#issuecomment-319724084