### PR TITLE
Applies updates and standards across cfn templates

### DIFF
--- a/docs/files/cfn/templates/watchmaker-lx-autoscale.template
+++ b/docs/files/cfn/templates/watchmaker-lx-autoscale.template
@@ -218,6 +218,12 @@
             "Type" : "String",
             "Default" : ""
         },
+        "WatchmakerAdminUsers" :
+        {
+            "Description" : "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
+            "Type" : "String",
+            "Default" : ""
+        },
         "CfnEndpointUrl" :
         {
             "Description" : "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
@@ -699,7 +705,7 @@
                                 { "Fn::Join" : [ "", [
                                     "watchmaker --log-level debug",
                                     " --log-dir /var/log/watchmaker",
-                                    " --noreboot",
+                                    " --no-reboot",
                                     {
                                         "Fn::If" :
                                         [
@@ -747,6 +753,18 @@
                                             ]]},
                                             ""
                                         ]
+                                    },
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseAdminUsers",
+                                            { "Fn::Join" : [ "", [
+                                                " --admin-users \"",
+                                                { "Ref" : "WatchmakerAdminUsers" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
                                     }
                                 ]]}
                             }
@@ -762,8 +780,8 @@
                                 { "Fn::Join" : [ "", [
                                     "watchmaker --log-level debug",
                                     " --log-dir /var/log/watchmaker",
-                                    " --saltstates None",
-                                    " --noreboot",
+                                    " --salt-states None",
+                                    " --no-reboot",
                                     {
                                         "Fn::If" :
                                         [
@@ -793,7 +811,7 @@
                                         [
                                             "UseOuPath",
                                             { "Fn::Join" : [ "", [
-                                                " --oupath \"",
+                                                " --ou-path \"",
                                                 { "Ref" : "WatchmakerOuPath" },
                                                 "\""
                                             ]]},
@@ -807,6 +825,18 @@
                                             { "Fn::Join" : [ "", [
                                                 " --admin-groups \"",
                                                 { "Ref" : "WatchmakerAdminGroups" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    },
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseAdminUsers",
+                                            { "Fn::Join" : [ "", [
+                                                " --admin-users \"",
+                                                { "Ref" : "WatchmakerAdminUsers" },
                                                 "\""
                                             ]]},
                                             ""

--- a/docs/files/cfn/templates/watchmaker-lx-autoscale.template
+++ b/docs/files/cfn/templates/watchmaker-lx-autoscale.template
@@ -38,10 +38,11 @@
         },
         "AppScriptUrl" :
         {
-            "Description" : "(Optional) URL to the application script. Leave blank to launch without an application script",
+            "Description" : "(Optional) Region-based HTTPS URL to the application script in an S3 bucket. If using FIPS-enabled AMI, script must be KMS-encrypted. Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
             "Type" : "String",
             "Default" : "",
-            "AllowedPattern" : "^$|^http[s]?://.*$"
+            "AllowedPattern" : "^$|^https://s3-(.*)$",
+            "ConstraintDescription" : "Must use a region-based HTTPS S3 endpoint (starts with \"s3-\"), see http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region"
         },
         "AppVolumeDevice" :
         {
@@ -476,6 +477,21 @@
             "Type" : "AWS::AutoScaling::LaunchConfiguration",
             "Metadata" : {
                 "ToggleCfnInitUpdate" : { "Ref" : "ToggleCfnInitUpdate" },
+                "AWS::CloudFormation::Authentication" :
+                {
+                    "Fn::If" :
+                    [
+                        "AssignInstanceRole",
+                        {
+                            "Ec2IamRole" :
+                            {
+                              "type" : "S3",
+                              "roleName" : { "Ref" : "InstanceRole" }
+                            }
+                        },
+                        { "Ref" : "AWS::NoValue" }
+                    ]
+                },
                 "AWS::CloudFormation::Init" :
                 {
                     "configSets" :
@@ -629,7 +645,7 @@
                                   " --index-url=\"$PYPI_URL\"",
                                   " --trusted-host=\"$PYPI_HOST\"",
                                   " --allow-all-external",
-                                  " --upgrade pip setuptools watchmaker\n\n",
+                                  " --upgrade pip setuptools watchmaker\n\n"
                                 ]]},
                                 "mode" : "000700",
                                 "owner" : "root",
@@ -809,7 +825,8 @@
                                 "source" : { "Ref" : "AppScriptUrl" },
                                 "mode" : "000700",
                                 "owner" : "root",
-                                "group" : "root"
+                                "group" : "root",
+                                "authentication" : "Ec2IamRole"
                             }
                         },
                         "commands" :

--- a/docs/files/cfn/templates/watchmaker-lx-autoscale.template
+++ b/docs/files/cfn/templates/watchmaker-lx-autoscale.template
@@ -650,7 +650,6 @@
                                   "pip install",
                                   " --index-url=\"$PYPI_URL\"",
                                   " --trusted-host=\"$PYPI_HOST\"",
-                                  " --allow-all-external",
                                   " --upgrade pip setuptools watchmaker\n\n"
                                 ]]},
                                 "mode" : "000700",
@@ -1059,7 +1058,6 @@
                         "pip install",
                         " --index-url=\"$PYPI_URL\"",
                         " --trusted-host=\"$PYPI_HOST\"",
-                        " --allow-all-external",
                         " --upgrade pip setuptools\n\n",
 
                         "# Fix python urllib3 warnings\n",
@@ -1067,14 +1065,12 @@
                         "pip install",
                         " --index-url=\"$PYPI_URL\"",
                         " --trusted-host=\"$PYPI_HOST\"",
-                        " --allow-all-external",
                         " --upgrade pyopenssl ndg-httpsclient pyasn1\n\n",
 
                         "# Get cfn utils\n",
                         "pip install",
                         " --index-url=\"$PYPI_URL\"",
                         " --trusted-host=\"$PYPI_HOST\"",
-                        " --allow-all-external",
                         " --upgrade ",
                         { "Ref" : "CfnBootstrapUtilsUrl" },
                         "\n\n",

--- a/docs/files/cfn/templates/watchmaker-lx-instance.template
+++ b/docs/files/cfn/templates/watchmaker-lx-instance.template
@@ -600,7 +600,6 @@
                                   "pip install",
                                   " --index-url=\"$PYPI_URL\"",
                                   " --trusted-host=\"$PYPI_HOST\"",
-                                  " --allow-all-external",
                                   " --upgrade pip setuptools watchmaker\n\n"
                                 ]]},
                                 "mode" : "000700",
@@ -1052,7 +1051,6 @@
                         "pip install",
                         " --index-url=\"$PYPI_URL\"",
                         " --trusted-host=\"$PYPI_HOST\"",
-                        " --allow-all-external",
                         " --upgrade pip setuptools\n\n",
 
                         "# Fix python urllib3 warnings\n",
@@ -1060,14 +1058,12 @@
                         "pip install",
                         " --index-url=\"$PYPI_URL\"",
                         " --trusted-host=\"$PYPI_HOST\"",
-                        " --allow-all-external",
                         " --upgrade pyopenssl ndg-httpsclient pyasn1\n\n",
 
                         "# Get cfn utils\n",
                         "pip install",
                         " --index-url=\"$PYPI_URL\"",
                         " --trusted-host=\"$PYPI_HOST\"",
-                        " --allow-all-external",
                         " --upgrade ",
                         { "Ref" : "CfnBootstrapUtilsUrl" },
                         "\n\n",

--- a/docs/files/cfn/templates/watchmaker-lx-instance.template
+++ b/docs/files/cfn/templates/watchmaker-lx-instance.template
@@ -38,10 +38,11 @@
         },
         "AppScriptUrl" :
         {
-            "Description" : "(Optional) URL to the application script. Leave blank to launch without an application script",
+            "Description" : "(Optional) Region-based HTTPS URL to the application script in an S3 bucket. If using FIPS-enabled AMI, script must be KMS-encrypted. Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
             "Type" : "String",
             "Default" : "",
-            "AllowedPattern" : "^$|^http[s]?://.*$"
+            "AllowedPattern" : "^$|^https://s3-(.*)$",
+            "ConstraintDescription" : "Must use a region-based HTTPS S3 endpoint (starts with \"s3-\"), see http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region"
         },
         "AppVolumeDevice" :
         {
@@ -432,6 +433,21 @@
             },
             "Metadata" : {
                 "ToggleCfnInitUpdate" : { "Ref" : "ToggleCfnInitUpdate" },
+                "AWS::CloudFormation::Authentication" :
+                {
+                    "Fn::If" :
+                    [
+                        "AssignInstanceRole",
+                        {
+                            "Ec2IamRole" :
+                            {
+                              "type" : "S3",
+                              "roleName" : { "Ref" : "InstanceRole" }
+                            }
+                        },
+                        { "Ref" : "AWS::NoValue" }
+                    ]
+                },
                 "AWS::CloudFormation::Init" :
                 {
                     "configSets" :
@@ -585,7 +601,7 @@
                                   " --index-url=\"$PYPI_URL\"",
                                   " --trusted-host=\"$PYPI_HOST\"",
                                   " --allow-all-external",
-                                  " --upgrade pip setuptools watchmaker\n\n",
+                                  " --upgrade pip setuptools watchmaker\n\n"
                                 ]]},
                                 "mode" : "000700",
                                 "owner" : "root",
@@ -813,7 +829,8 @@
                                 "source" : { "Ref" : "AppScriptUrl" },
                                 "mode" : "000700",
                                 "owner" : "root",
-                                "group" : "root"
+                                "group" : "root",
+                                "authentication" : "Ec2IamRole"
                             }
                         },
                         "commands" :

--- a/docs/files/cfn/templates/watchmaker-lx-instance.template
+++ b/docs/files/cfn/templates/watchmaker-lx-instance.template
@@ -655,7 +655,7 @@
                                 { "Fn::Join" : [ "", [
                                     "watchmaker --log-level debug",
                                     " --log-dir /var/log/watchmaker",
-                                    " --noreboot",
+                                    " --no-reboot",
                                     {
                                         "Fn::If" :
                                         [
@@ -742,8 +742,8 @@
                                 { "Fn::Join" : [ "", [
                                     "watchmaker --log-level debug",
                                     " --log-dir /var/log/watchmaker",
-                                    " --saltstates None",
-                                    " --noreboot",
+                                    " --salt-states None",
+                                    " --no-reboot",
                                     {
                                         "Fn::If" :
                                         [

--- a/docs/files/cfn/templates/watchmaker-win-autoscale.template
+++ b/docs/files/cfn/templates/watchmaker-win-autoscale.template
@@ -27,10 +27,11 @@
         },
         "AppScriptUrl" :
         {
-            "Description" : "(Optional) URL to the application script. Leave blank to launch without an application script",
+            "Description" : "(Optional) Region-based HTTPS URL to the application script in an S3 bucket. Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
             "Type" : "String",
             "Default" : "",
-            "AllowedPattern" : "^$|^http[s]?://.*$"
+            "AllowedPattern" : "^$|^https://s3-(.*)$",
+            "ConstraintDescription" : "Must use a region-based HTTPS S3 endpoint (starts with \"s3-\"), see http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region"
         },
         "AppVolumeDevice" :
         {
@@ -446,6 +447,21 @@
             "Type" : "AWS::AutoScaling::LaunchConfiguration",
             "Metadata" : {
                 "ToggleCfnInitUpdate" : { "Ref" : "ToggleCfnInitUpdate" },
+                "AWS::CloudFormation::Authentication" :
+                {
+                    "Fn::If" :
+                    [
+                        "AssignInstanceRole",
+                        {
+                            "Ec2IamRole" :
+                            {
+                              "type" : "S3",
+                              "roleName" : { "Ref" : "InstanceRole" }
+                            }
+                        },
+                        { "Ref" : "AWS::NoValue" }
+                    ]
+                },
                 "AWS::CloudFormation::Init" :
                 {
                     "configSets" :
@@ -762,7 +778,8 @@
                         {
                             "c:\\cfn\\scripts\\make-app" :
                             {
-                                "source" : { "Ref" : "AppScriptUrl" }
+                                "source" : { "Ref" : "AppScriptUrl" },
+                                "authentication" : "Ec2IamRole"
                             }
                         },
                         "commands" :

--- a/docs/files/cfn/templates/watchmaker-win-autoscale.template
+++ b/docs/files/cfn/templates/watchmaker-win-autoscale.template
@@ -604,7 +604,7 @@
                                     "& \"$BootstrapFile\" -PythonUrl \"$PythonUrl\" -Verbose -ErrorAction Stop\n\n",
 
                                     "# Install watchmaker\n",
-                                    "pip install --index-url=\"$PypiUrl\" --trusted-host=\"$PypiHost\" --allow-all-external --upgrade pip setuptools watchmaker\n\n"
+                                    "pip install --index-url=\"$PypiUrl\" --trusted-host=\"$PypiHost\" --upgrade pip setuptools watchmaker\n\n"
                                 ]]}
                             }
                         },

--- a/docs/files/cfn/templates/watchmaker-win-instance.template
+++ b/docs/files/cfn/templates/watchmaker-win-instance.template
@@ -555,7 +555,7 @@
                                     "& \"$BootstrapFile\" -PythonUrl \"$PythonUrl\" -Verbose -ErrorAction Stop\n\n",
 
                                     "# Install watchmaker\n",
-                                    "pip install --index-url=\"$PypiUrl\" --trusted-host=\"$PypiHost\" --allow-all-external --upgrade pip setuptools watchmaker\n\n"
+                                    "pip install --index-url=\"$PypiUrl\" --trusted-host=\"$PypiHost\" --upgrade pip setuptools watchmaker\n\n"
                                 ]]}
                             }
                         },

--- a/docs/files/cfn/templates/watchmaker-win-instance.template
+++ b/docs/files/cfn/templates/watchmaker-win-instance.template
@@ -197,6 +197,12 @@
             "Type" : "String",
             "Default" : ""
         },
+        "WatchmakerAdminUsers" :
+        {
+            "Description" : "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
+            "Type" : "String",
+            "Default" : ""
+        },
         "CfnEndpointUrl" :
         {
             "Description" : "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
@@ -650,6 +656,18 @@
                                             ""
                                         ]
                                     },
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseAdminUsers",
+                                            { "Fn::Join" : [ "", [
+                                                " --admin-users \"",
+                                                { "Ref" : "WatchmakerAdminUsers" },
+                                                "\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    },
                                     " }\""
                                 ]]}
                             }
@@ -732,6 +750,18 @@
                                                 " --admin-groups \\\"",
                                                 { "Ref" : "WatchmakerAdminGroups" },
                                                 "\\\""
+                                            ]]},
+                                            ""
+                                        ]
+                                    },
+                                    {
+                                        "Fn::If" :
+                                        [
+                                            "UseAdminUsers",
+                                            { "Fn::Join" : [ "", [
+                                                " --admin-users \"",
+                                                { "Ref" : "WatchmakerAdminUsers" },
+                                                "\""
                                             ]]},
                                             ""
                                         ]

--- a/docs/files/cfn/templates/watchmaker-win-instance.template
+++ b/docs/files/cfn/templates/watchmaker-win-instance.template
@@ -27,10 +27,11 @@
         },
         "AppScriptUrl" :
         {
-            "Description" : "(Optional) URL to the application script. Leave blank to launch without an application script",
+            "Description" : "(Optional) Region-based HTTPS URL to the application script in an S3 bucket. Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
             "Type" : "String",
             "Default" : "",
-            "AllowedPattern" : "^$|^http[s]?://.*$"
+            "AllowedPattern" : "^$|^https://s3-(.*)$",
+            "ConstraintDescription" : "Must use a region-based HTTPS S3 endpoint (starts with \"s3-\"), see http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region"
         },
         "AppVolumeDevice" :
         {
@@ -391,6 +392,21 @@
             },
             "Metadata" : {
                 "ToggleCfnInitUpdate" : { "Ref" : "ToggleCfnInitUpdate" },
+                "AWS::CloudFormation::Authentication" :
+                {
+                    "Fn::If" :
+                    [
+                        "AssignInstanceRole",
+                        {
+                            "Ec2IamRole" :
+                            {
+                              "type" : "S3",
+                              "roleName" : { "Ref" : "InstanceRole" }
+                            }
+                        },
+                        { "Ref" : "AWS::NoValue" }
+                    ]
+                },
                 "AWS::CloudFormation::Init" :
                 {
                     "configSets" :
@@ -731,7 +747,8 @@
                         {
                             "c:\\cfn\\scripts\\make-app" :
                             {
-                                "source" : { "Ref" : "AppScriptUrl" }
+                                "source" : { "Ref" : "AppScriptUrl" },
+                                "authentication" : "Ec2IamRole"
                             }
                         },
                         "commands" :


### PR DESCRIPTION
* Includes `appscript` workaround for FIPS-enabled AMIs.  Script must be S3-hosted and KMS-encrypted, and the instance must be assigned an instance role with appropriate permissions to retrieve and decrypt the object.
* Updates all templates so that `appscript` must be S3-hosted (if used). Improves security posture for applications.
* Corrects usage of several watchmaker options, as the options were renamed at some point.
* Eliminates a deprecation warning when calling pip install.