### PR TITLE
Forces pip to install wheel 0.29.0 if necessary

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -152,7 +152,7 @@ specify something like this for EC2 userdata:
     PYPI_URL=https://pypi.org/simple
 
     # Install pip
-    curl "$PIP_URL" | python - --index-url="$PYPI_URL"
+    curl "$PIP_URL" | python - --index-url="$PYPI_URL" wheel==0.29.0
 
     # Install git
     yum -y install git

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -81,7 +81,7 @@ on the [CLI](#watchmaker-from-the-cli). Here is an example:
 
 ```shell
 #!/bin/sh
-PIP_URL=https://bootstrap.pypa.io/get-pip.py
+PIP_URL=https://bootstrap.pypa.io/get-pip.py wheel==0.29.0
 PYPI_URL=https://pypi.org/simple
 
 # Install pip
@@ -101,7 +101,7 @@ Alternatively, cloud-config directives can also be used on **Linux**:
 
 runcmd:
   - |
-    PIP_URL=https://bootstrap.pypa.io/get-pip.py
+    PIP_URL=https://bootstrap.pypa.io/get-pip.py wheel==0.29.0
     PYPI_URL=https://pypi.org/simple
 
     # Install pip


### PR DESCRIPTION
If wheel is not already installed, then by default pip will install
it. This forces pip to install a version of wheel that works on
EL6/py2.6. If running on EL7, the "pip install --upgrade" line will
update wheel to the latest version (which works fine on EL7/py2.7).

This is a doc-only patch. No code is modified.