### PR TITLE
Modified heading text to fix anchor link issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ Watchmaker docs, in docstrings, or even on the web in blog posts, articles, and
 such. The official documentation is maintained within this project in
 docstrings or in the [docs][3] directory. Contributions are
 welcome, and are made the same way as any other code. See
-[Development](#development).
+[Development](#development-guide) guide.
 
 ## Feature Requests and Feedback
 
@@ -32,7 +32,7 @@ If you are proposing a feature:
 *   Remember that this is a community-driven, open-source project, and that
     code contributions are welcome. :)
 
-## Development
+## Development Guide
 
 To set up `watchmaker` for local development:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,10 +39,10 @@ systems.
 Watchmaker includes the _workers_ listed below. See the corresponding sections
 for details on their configuration parameters.
 
-*   [salt](#salt)
-*   [yum (Linux-only)](#yum-linux-only)
+*   [salt](#salt-worker)
+*   [yum (linux-only)](#yum-worker-linux-only)
 
-### salt
+### salt worker
 
 Parameters supported by the Salt Worker:
 
@@ -109,7 +109,7 @@ Parameters supported by the Salt Worker:
     `installer_url` (_string_): (Windows-only) URL to the Salt Minion installer
     for Windows.
 
-### yum (linux-only)
+### yum worker (linux-only)
 
 Parameters supported by the Yum Worker:
 


### PR DESCRIPTION
Workaround for [#468](https://github.com/plus3it/watchmaker/issues/468) 

Problem appears to be due to a bug somewhere in the Markdown->reStructuredtext->HTML conversion chain (m2r, sphinx).  When the heading name and reference link name are the same and the reference link is placed **before** the heading, the heading anchor link is given an arbitrary `id<#>` name and not the heading name.

Making the heading name and reference link name different fixes the issue.  The other workaround is to place the reference link after the heading but this is not feasible because it would require a re-write of the document.