### PR TITLE
Uses a custom path for salt configuration

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -55,6 +55,21 @@ label may not be related to the error you are encountering.
 Watchmaker is supported on RedHat 7 and CentOS 7. See the [index](index.html)
 page for a list of all supported operating systems.
 
+## Can I use the underlying salt functionality directly?
+
+Yes, by passing watchmaker's salt configuration directory to the salt command,
+using the `-c|--config-dir` argument:
+
+*   Linux: `/opt/watchmaker/salt`
+*   Windows: `C:\Watchmaker\salt\conf`
+
+For example:
+
+```
+# -c|--config-dir
+salt-call -c /opt/watchmaker/salt state.show_top
+```
+
 ## Can I use watchmaker to toggle my RedHat/Centos host's FIPS mode?
 
 Yes, indirectly. Because watchmaker implements most of its functionality via
@@ -62,7 +77,7 @@ Yes, indirectly. Because watchmaker implements most of its functionality via
 SaltStack functionality to effect the desired change. This is done from the
 commandline - as root - by executing:
 
-*   Disable FIPS-mode: `salt-call --local ash.fips_disable`
-*   Enable FIPS-mode: `salt-call --local ash.fips_enable`
+*   Disable FIPS-mode: `salt-call -c /opt/watchmaker/salt ash.fips_disable`
+*   Enable FIPS-mode: `salt-call -c /opt/watchmaker/salt ash.fips_enable`
 
 And then rebooting the system.

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -36,12 +36,12 @@ class SaltBase(ManagerBase):
 
         salt_content: (:obj:`str`)
             URL to a salt content archive (zip file) that will be uncompressed
-            in the salt "srv" directory. This typically is used to create a
-            top.sls file and to populate salt's file_roots.
+            in the watchmaker salt "srv" directory. This typically is used to
+            create a top.sls file and to populate salt's file_roots.
             (*Default*: ``''``)
 
-            - *Linux*: ``/srv/salt``
-            - *Windows*: ``C:\Salt\srv``
+            - *Linux*: ``/srv/watchmaker/salt``
+            - *Windows*: ``C:\Watchmaker\Salt\srv``
 
         salt_states: (:obj:`str`)
             Comma-separated string of salt states to execute. Accepts two
@@ -152,7 +152,8 @@ class SaltBase(ManagerBase):
 
         for salt_dir in [
             self.salt_base_env,
-            self.salt_formula_root
+            self.salt_formula_root,
+            self.salt_conf_path
         ]:
             try:
                 os.makedirs(salt_dir)
@@ -284,7 +285,9 @@ class SaltBase(ManagerBase):
             self.salt_call,
             '--local',
             '--retcode-passthrough',
-            '--no-color'
+            '--no-color',
+            '--config-dir',
+            self.salt_conf_path
         ]
         if isinstance(command, list):
             cmd.extend(command)
@@ -530,9 +533,8 @@ class SaltLinux(SaltBase, LinuxManager):
 
         # Set up variables for paths to Salt directories and applications.
         self.salt_call = '/usr/bin/salt-call'
-        self.salt_conf_path = '/etc/salt'
-        self.salt_min_path = '/etc/salt/minion'
-        self.salt_srv = '/srv/salt'
+        self.salt_conf_path = '/opt/watchmaker/salt'
+        self.salt_srv = '/srv/watchmaker/salt'
         self.salt_log_dir = self.system_params['logdir']
         self.salt_working_dir = self.system_params['workingdir']
         self.salt_working_dir_prefix = 'salt-'
@@ -591,7 +593,8 @@ class SaltLinux(SaltBase, LinuxManager):
             'hash_type': 'sha512',
             'file_roots': {'base': file_roots},
             'pillar_roots': {'base': [str(self.salt_pillar_root)]},
-            'pillar_merge_lists': True
+            'pillar_merge_lists': True,
+            'conf_dir': self.salt_conf_path
         }
 
         super(SaltLinux, self)._build_salt_formula(extract_dir)
@@ -678,9 +681,11 @@ class SaltWindows(SaltBase, WindowsManager):
         self.salt_root = os.sep.join((sys_drive, 'Salt'))
 
         self.salt_call = os.sep.join((self.salt_root, 'salt-call.bat'))
-        self.salt_conf_path = os.sep.join((self.salt_root, 'conf'))
-        self.salt_min_path = os.sep.join((self.salt_root, 'minion'))
-        self.salt_srv = os.sep.join((self.salt_root, 'srv'))
+        self.salt_wam_root = os.sep.join((
+            self.system_params['prepdir'],
+            'Salt'))
+        self.salt_conf_path = os.sep.join((self.salt_wam_root, 'conf'))
+        self.salt_srv = os.sep.join((self.salt_wam_root, 'srv'))
         self.salt_win_repo = os.sep.join((self.salt_srv, 'winrepo'))
         self.salt_log_dir = self.system_params['logdir']
         self.salt_working_dir = self.system_params['workingdir']
@@ -724,6 +729,7 @@ class SaltWindows(SaltBase, WindowsManager):
             'file_roots': {'base': file_roots},
             'pillar_roots': {'base': [str(self.salt_pillar_root)]},
             'pillar_merge_lists': True,
+            'conf_dir': self.salt_conf_path,
             'winrepo_source_dir': 'salt://winrepo',
             'winrepo_dir': os.sep.join((self.salt_win_repo, 'winrepo'))
         }


### PR DESCRIPTION
Previously, watchmaker modified the main salt config locations:

* `/etc/salt/minion.d/*`
* `C:\Salt\conf\minion.d\*`

The prior approach led to conflicts with users of salt, as they need to configure salt for their use case.

This patch moves the watchmaker salt configuration to its own directory:

* `/opt/watchmaker/salt`
* `C:\Watchmaker\Salt\conf`

To use the custom config location, Watchmaker now passes the config-dir option to salt-call:

* `salt-call --config-dir <config-dir>`

Fixes #430 
Fixes #402 