### PR TITLE
Azure CSE PowerShell

### DIFF
--- a/docs/files/bootstrap/watchmaker-bootstrap.ps1
+++ b/docs/files/bootstrap/watchmaker-bootstrap.ps1
@@ -143,4 +143,9 @@ if( ${GitUrl} ) {
 Reset-EnvironmentVariables
 Write-Verbose "Reset the PATH environment for this shell"
 
+if ("$Env:TEMP".TrimEnd("\") -eq "${Env:windir}\System32\config\systemprofile\AppData\Local\Temp") {
+  $Env:TEMP, $Env:TMP = "${Env:windir}\Temp", "${Env:windir}\Temp"
+  Write-Verbose "Forced TEMP envs to ${Env:windir}\Temp"
+}
+
 Write-Verbose "${__ScriptName} complete!"


### PR DESCRIPTION
Python/Watchmaker install:
	- Changed the Python install to use "Start-Process" with -wait
	- Explicitly modify the session path variable to add Python
	  folders
	- Separated the download/install of Watchmaker from the other
	  Python modules
	- Set the download destination for the Python module to be the
	  $env:windir\Temp folder
	- Added code to delete all non-log files from the
	  $env:windir\Temp folder