### PR TITLE
Storage-handler for Fifth-generation Instance-types

### DIFF
--- a/docs/files/templates/lx-autoscale/watchmaker-lx-autoscale.template
+++ b/docs/files/templates/lx-autoscale/watchmaker-lx-autoscale.template
@@ -1,1199 +1,1293 @@
 {
-    "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description" : "This template creates an Autoscaling Group and Launch Configuration that deploys Linux instances with Watchmaker, which applies the DISA STIG.",
-    "Parameters" :
-    {
-        "AmiId" :
-        {
-            "Description" : "ID of the AMI to launch",
-            "Type" : "String",
-            "AllowedPattern" : "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$"
-        },
-        "AmiDistro" :
-        {
-            "Description" : "Linux distro of the AMI",
-            "Type" : "String",
-            "AllowedValues" :
-            [
-                "AmazonLinux",
-                "CentOS",
-                "RedHat"
-            ]
-        },
-        "AppScriptParams" :
-        {
-            "Description" : "Parameter string to pass to the application script. Ignored if \"AppScriptUrl\" is blank",
-            "Type" : "String"
-        },
-        "AppScriptShell" :
-        {
-            "Description" : "Shell with which to execute the application script. Ignored if \"AppScriptUrl\" is blank",
-            "Type" : "String",
-            "Default" : "bash",
-            "AllowedValues" :
-            [
-                "bash",
-                "python"
-            ]
-        },
-        "AppScriptUrl" :
-        {
-            "Description" : "(Optional) S3 URL to the application script in an S3 bucket (s3://). Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
-            "Type" : "String",
-            "Default" : "",
-            "AllowedPattern" : "^$|^s3://(.*)$",
-            "ConstraintDescription" : "Must use an S3 URL (starts with \"s3://\")"
-        },
-        "AppVolumeDevice" :
-        {
-            "Description" : "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume",
-            "Type" : "String",
-            "Default" : "",
-            "AllowedValues" :
-            [
-                "",
-                "/dev/xvdf",
-                "/dev/xvdg",
-                "/dev/xvdh",
-                "/dev/xvdi",
-                "/dev/xvdj"
-            ]
-        },
-        "AppVolumeMountPath" :
-        {
-            "Description" : "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
-            "Type" : "String",
-            "Default" : "/opt/data",
-            "AllowedPattern" : "/.*"
-        },
-        "AppVolumeType" :
-        {
-            "Description" : "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
-            "Type" : "String",
-            "Default" : "gp2",
-            "AllowedValues" :
-            [
-                "gp2",
-                "io1",
-                "sc1",
-                "st1",
-                "standard"
-            ]
-        },
-        "AppVolumeSize" :
-        {
-            "Description" : "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
-            "Type" : "Number",
-            "Default" : "1",
-            "MinValue": "1",
-            "MaxValue": "16384",
-            "ConstraintDescription" : "Must be between 1GB and 16384GB."
-        },
-        "KeyPairName" :
-        {
-            "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
-            "Type" : "AWS::EC2::KeyPair::KeyName"
-        },
-        "InstanceType" :
-        {
-            "Description" : "Amazon EC2 instance type",
-            "Type" : "String",
-            "Default" : "t2.micro",
-            "AllowedValues" :
-            [
-                "t2.micro",
-                "t2.small",
-                "t2.medium",
-                "t2.large",
-                "c4.large",
-                "c4.xlarge",
-                "m4.large",
-                "m4.xlarge"
-            ]
-        },
-        "InstanceRole" :
-        {
-            "Description" : "(Optional) IAM instance role to apply to the instance(s)",
-            "Type" : "String",
-            "Default" : ""
-        },
-        "MinCapacity" :
-        {
-            "Description" : "Minimum number of instances in the Autoscaling Group",
-            "Type" : "Number",
-            "Default" : "1"
-        },
-        "MaxCapacity" :
-        {
-            "Description" : "Maximum number of instances in the Autoscaling Group",
-            "Type" : "Number",
-            "Default" : "2"
-        },
-        "DesiredCapacity" :
-        {
-            "Description" : "Desired number of instances in the Autoscaling Group",
-            "Type" : "Number",
-            "Default" : "1"
-        },
-        "NoPublicIp" :
-        {
-            "Description" : "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
-            "Type" : "String",
-            "Default" : "true",
-            "AllowedValues" :
-            [
-                "false",
-                "true"
-            ]
-        },
-        "NoReboot" :
-        {
-            "Description" : "Controls whether to reboot the instance as the last step of cfn-init execution",
-            "Type" : "String",
-            "Default" : "false",
-            "AllowedValues" :
-            [
-                "false",
-                "true"
-            ]
-        },
-        "NoUpdates" :
-        {
-            "Description" : "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
-            "Type" : "String",
-            "Default" : "false",
-            "AllowedValues" :
-            [
-                "false",
-                "true"
-            ]
-        },
-        "SecurityGroupIds" :
-        {
-            "Description" : "List of security groups to apply to the instance(s)",
-            "Type" : "List<AWS::EC2::SecurityGroup::Id>"
-        },
-        "SubnetIds" :
-        {
-            "Type" : "List<AWS::EC2::Subnet::Id>",
-            "Description" : "List of subnets to associate to the Autoscaling Group"
-        },
-        "PypiIndexUrl" :
-        {
-            "Description" : "URL to the PyPi Index",
-            "Type" : "String",
-            "Default" : "https://pypi.org/simple",
-            "AllowedPattern" : "^http[s]?://.*$"
-        },
-        "WatchmakerConfig" :
-        {
-            "Description" : "(Optional) URL to a Watchmaker config file",
-            "Type" : "String",
-            "Default" : "",
-            "AllowedPattern" : "^$|^http[s]?://.*$"
-        },
-        "WatchmakerEnvironment" :
-        {
-            "Description" : "Environment in which the instance is being deployed",
-            "Type" : "String",
-            "Default" : "",
-            "AllowedValues" :
-            [
-                "",
-                "dev",
-                "test",
-                "prod"
-            ]
-        },
-        "WatchmakerOuPath" :
-        {
-            "Description" : "(Optional) DN of the OU to place the instance when joining a domain. If blank and \"WatchmakerEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"WatchmakerEnvironment\" is \"false\"",
-            "Type" : "String",
-            "Default" : "",
-            "AllowedPattern" : "^$|^(OU=.+,)+(DC=.+)+$"
-        },
-        "WatchmakerAdminGroups" :
-        {
-            "Description" : "(Optional) Colon-separated list of domain groups that should have admin permissions on the EC2 instance",
-            "Type" : "String",
-            "Default" : ""
-        },
-        "WatchmakerAdminUsers" :
-        {
-            "Description" : "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
-            "Type" : "String",
-            "Default" : ""
-        },
-        "WatchmakerS3Source" :
-        {
-            "Description" : "Flag that tells watchmaker to use its instance role to retrieve watchmaker content from S3",
-            "Type" : "String",
-            "Default" : "false",
-            "AllowedValues" :
-            [
-                "false",
-                "true"
-            ]
-        },
-        "CfnEndpointUrl" :
-        {
-            "Description" : "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
-            "Type" : "String",
-            "Default" : "https://cloudformation.us-east-1.amazonaws.com",
-            "AllowedPattern" : "^$|^http[s]?://.*$"
-        },
-        "CfnGetPipUrl" :
-        {
-            "Description" : "URL to get-pip.py",
-            "Type" : "String",
-            "Default" : "https://bootstrap.pypa.io/get-pip.py",
-            "AllowedPattern" : "^http[s]?://.*\\.py$"
-        },
-        "CfnBootstrapUtilsUrl" :
-        {
-            "Description" : "URL to aws-cfn-bootstrap-latest.tar.gz",
-            "Type" : "String",
-            "Default" : "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-            "AllowedPattern" : "^http[s]?://.*\\.tar\\.gz$"
-        },
-        "ToggleCfnInitUpdate" :
-        {
-            "Description" : "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
-            "Type" : "String",
-            "Default" : "A",
-            "AllowedValues" :
-            [
-                "A",
-                "B"
-            ]
-        },
-        "ToggleNewInstances" :
-        {
-            "Description" : "A/B toggle that forces a change to instance userdata, triggering new instances via the Autoscale update policy",
-            "Type" : "String",
-            "Default" : "A",
-            "AllowedValues" :
-            [
-                "A",
-                "B"
-            ]
-        }
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "AssignInstanceRole": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "InstanceRole" }, "" ] }
+      ]
     },
-    "Conditions" :
-    {
-        "ExecuteAppScript" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AppScriptUrl" }, "" ] } ]
-        },
-        "CreateAppVolume" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AppVolumeDevice" }, "" ] } ]
-        },
-        "UseWamConfig" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerConfig" }, "" ] } ]
-        },
-        "UseOuPath" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerOuPath" }, "" ] } ]
-        },
-        "UseAdminGroups" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerAdminGroups" }, "" ] } ]
-        },
-        "UseAdminUsers" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerAdminUsers" }, "" ] } ]
-        },
-        "UseS3Source" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerS3Source" }, "false" ] } ]
-        },
-        "UseEnvironment" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerEnvironment" }, "" ] } ]
-        },
-        "UseCfnUrl" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "CfnEndpointUrl" }, "" ] } ]
-        },
-        "InstallUpdates" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoUpdates" }, "true" ] } ]
-        },
-        "Reboot" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoReboot" }, "true" ] } ]
-        },
-        "AssignInstanceRole" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "InstanceRole" }, "" ] } ]
-        },
-        "AssignPublicIp" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoPublicIp" }, "true" ] } ]
-        }
+    "AssignPublicIp": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "NoPublicIp" }, "true" ] }
+      ]
     },
-    "Mappings" :
-    {
-        "Distro2RootDevice" :
-        {
-            "AmazonLinux" : { "DeviceName" : "xvda" },
-            "RedHat" : { "DeviceName" : "sda1" },
-            "CentOS" : { "DeviceName" : "sda1" }
-        }
+    "CreateAppVolume": {
+      "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "true" ]
     },
-    "Metadata" :
-    {
-        "AWS::CloudFormation::Interface" :
-        {
-            "ParameterGroups" :
-            [
-                {
-                    "Label" :
-                    {
-                      "default" : "EC2 Instance Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "AmiId",
-                        "AmiDistro",
-                        "InstanceType",
-                        "InstanceRole",
-                        "KeyPairName",
-                        "NoPublicIp",
-                        "NoReboot",
-                        "NoUpdates",
-                        "SecurityGroupIds"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                      "default" : "EC2 Watchmaker Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "PypiIndexUrl",
-                        "WatchmakerConfig",
-                        "WatchmakerEnvironment",
-                        "WatchmakerOuPath",
-                        "WatchmakerAdminGroups",
-                        "WatchmakerAdminUsers",
-                        "WatchmakerS3Source"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                        "default" : "EC2 Application Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "AppScriptUrl",
-                        "AppScriptParams",
-                        "AppScriptShell"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                        "default" : "EC2 Application EBS Volume"
-                    },
-                    "Parameters" :
-                    [
-                        "AppVolumeDevice",
-                        "AppVolumeMountPath",
-                        "AppVolumeSize",
-                        "AppVolumeType"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                        "default" : "AutoScale Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "DesiredCapacity",
-                        "MinCapacity",
-                        "MaxCapacity"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                        "default" : "Network Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "SubnetIds"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                        "default" : "CloudFormation Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "CfnEndpointUrl",
-                        "CfnGetPipUrl",
-                        "CfnBootstrapUtilsUrl",
-                        "ToggleCfnInitUpdate",
-                        "ToggleNewInstances"
-                    ]
-                }
-            ],
-            "ParameterLabels" :
-            {
-                "ToggleCfnInitUpdate" :
-                {
-                    "default" : "Force Cfn Init Update"
-                },
-                "ToggleNewInstances" :
-                {
-                    "default" : "Force New Instances"
-                }
-            }
-        }
+    "ExecuteAppScript": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "AppScriptUrl" }, "" ] }
+      ]
     },
-    "Resources" :
-    {
-        "WatchmakerAutoScalingGroup" :
-        {
-            "Type" : "AWS::AutoScaling::AutoScalingGroup",
-            "UpdatePolicy" : {
-                "AutoScalingRollingUpdate" : {
-                    "MinInstancesInService" : "1",
-                    "MaxBatchSize" : "2",
-                    "WaitOnResourceSignals" : "true",
-                    "PauseTime" : "PT30M"
-                }
-            },
-            "CreationPolicy" :
-            {
-                "ResourceSignal" :
-                {
-                    "Count" : { "Ref" : "DesiredCapacity" },
-                    "Timeout" : "PT30M"
-                }
-            },
-            "Properties" :
-            {
-                "VPCZoneIdentifier" : { "Ref" : "SubnetIds" },
-                "LaunchConfigurationName" : { "Ref" : "WatchmakerLaunchConfig" },
-                "MinSize" : { "Ref" : "MinCapacity" },
-                "MaxSize" : { "Ref" : "MaxCapacity" },
-                "DesiredCapacity" : { "Ref" : "DesiredCapacity" },
-                "Tags" :
-                [
-                    {
-                        "Key" : "Name",
-                        "Value" :
-                        { "Fn::Join" : [ "", [
-                            { "Ref" : "AWS::StackName" }
-                        ] ] },
-                        "PropagateAtLaunch" : "true"
-                    }
-                ]
-            }
+    "InstallUpdates": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "NoUpdates" }, "true" ] }
+      ]
+    },
+    "Reboot": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "NoReboot" }, "true" ] }
+      ]
+    },
+    "UseAdminGroups": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerAdminGroups" }, "" ] }
+      ]
+    },
+    "UseAdminUsers": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerAdminUsers" }, "" ] }
+      ]
+    },
+    "UseCfnUrl": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "CfnEndpointUrl" }, "" ] }
+      ]
+    },
+    "UseEnvironment": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerEnvironment" }, "" ] }
+      ]
+    },
+    "UseOuPath": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerOuPath" }, "" ] }
+      ]
+    },
+    "UseS3Source": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerS3Source" }, "false" ] }
+      ]
+    },
+    "UseWamConfig": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerConfig" }, "" ] }
+      ]
+    }
+  },
+  "Description": "This template creates an Autoscaling Group and Launch Configuration that deploys Linux instances with Watchmaker, which applies the DISA STIG.",
+  "Mappings": {
+    "Distro2RootDevice": {
+      "AmazonLinux": {
+        "DeviceName": "xvda"
+      },
+      "CentOS": {
+        "DeviceName": "sda1"
+      },
+      "RedHat": {
+        "DeviceName": "sda1"
+      }
+    },
+    "InstanceTypeCapabilities": {
+        "t2.micro": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
         },
-        "WatchmakerLaunchConfig" :
-        {
-            "Type" : "AWS::AutoScaling::LaunchConfiguration",
-            "Metadata" : {
-                "ToggleCfnInitUpdate" : { "Ref" : "ToggleCfnInitUpdate" },
-                "AWS::CloudFormation::Init" :
-                {
-                    "configSets" :
-                    {
-                        "launch" :
-                        [
-                            "setup",
-                            "watchmaker-install",
-                            "watchmaker-launch",
-                            {
-                                "Fn::If" :
-                                [
-                                    "ExecuteAppScript",
-                                    "make-app",
-                                    { "Ref" : "AWS::NoValue" }
-                                ]
-                            },
-                            "finalize",
-                            {
-                                "Fn::If" :
-                                [
-                                    "Reboot",
-                                    "reboot",
-                                    { "Ref" : "AWS::NoValue" }
-                                ]
-                            }
-                        ],
-                        "update" :
-                        [
-                            "setup",
-                            {
-                                "Fn::If" :
-                                [
-                                    "InstallUpdates",
-                                    "install-updates",
-                                    { "Ref" : "AWS::NoValue" }
-                                ]
-                            },
-                            "watchmaker-install",
-                            "watchmaker-update",
-                            {
-                                "Fn::If" :
-                                [
-                                    "ExecuteAppScript",
-                                    "make-app",
-                                    { "Ref" : "AWS::NoValue" }
-                                ]
-                            },
-                            "finalize",
-                            {
-                                "Fn::If" :
-                                [
-                                    "Reboot",
-                                    "reboot",
-                                    { "Ref" : "AWS::NoValue" }
-                                ]
-                            }
-                        ]
-                    },
-                    "setup" :
-                    {
-                        "files" :
-                        {
-                            "/etc/cfn/cfn-hup.conf" :
-                            {
-                                "content" :
-                                { "Fn::Join" : ["", [
-                                    "[main]\n",
-                                    "stack=", { "Ref" : "AWS::StackId" }, "\n",
-                                    "region=", { "Ref" : "AWS::Region" }, "\n",
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "AssignInstanceRole",
-                                            { "Fn::Join" : [ "", [
-                                                "role=",
-                                                { "Ref" : "InstanceRole" },
-                                                "\n"
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseCfnUrl",
-                                            { "Fn::Join" : [ "", [
-                                                "url=",
-                                                { "Ref" : "CfnEndpointUrl" },
-                                                "\n"
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    "interval=1", "\n",
-                                    "verbose=true", "\n"
-                                ]]},
-                                "mode"    : "000400",
-                                "owner"   : "root",
-                                "group"   : "root"
-                            },
-                            "/etc/cfn/hooks.d/cfn-auto-reloader.conf" :
-                            {
-                                "content" :
-                                { "Fn::Join" : ["", [
-                                    "[cfn-auto-reloader-hook]\n",
-                                    "triggers=post.update\n",
-                                    "path=Resources.WatchmakerLaunchConfig.Metadata\n",
-                                    "action=/opt/aws/bin/cfn-init -v -c update",
-                                    " --stack ", { "Ref" : "AWS::StackName" },
-                                    " --resource WatchmakerLaunchConfig",
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "AssignInstanceRole",
-                                            { "Fn::Join" : [ "", [
-                                                " --role ",
-                                                { "Ref" : "InstanceRole" }
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseCfnUrl",
-                                            { "Fn::Join" : [ "", [
-                                                " --url ",
-                                                { "Ref" : "CfnEndpointUrl" }
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    " --region ", { "Ref" : "AWS::Region" }, "\n",
-                                    "runas=root\n"
-                                ]]},
-                                "mode" : "000400",
-                                "owner" : "root",
-                                "group" : "root"
-                            },
-                            "/etc/cfn/scripts/watchmaker-install.sh" :
-                            {
-                                "content" :
-                                { "Fn::Join" : [ "", [
-                                  "#!/bin/bash\n\n",
-
-                                  "PYPI_URL=", { "Ref" : "PypiIndexUrl" }, "\n",
-
-                                  "pip install --index-url=\"$PYPI_URL\" wheel==0.29.0\n",
-
-                                  "pip install",
-                                  " --index-url=\"$PYPI_URL\"",
-                                  " --upgrade pip setuptools boto3 watchmaker\n\n"
-                                ]]},
-                                "mode" : "000700",
-                                "owner" : "root",
-                                "group" : "root"
-                            }
-                        },
-                        "services" :
-                        {
-                            "sysvinit" :
-                            {
-                                "cfn-hup" :
-                                {
-                                    "enabled" : "true",
-                                    "ensureRunning" : "true",
-                                    "files" :
-                                    [
-                                        "/etc/cfn/cfn-hup.conf",
-                                        "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "install-updates" :
-                    {
-                        "commands" :
-                        {
-                            "10-install-updates" :
-                            {
-                                "command" : "yum -y update"
-                            }
-                        }
-                    },
-                    "watchmaker-install" :
-                    {
-                        "commands" :
-                        {
-                            "10-watchmaker-install" :
-                            {
-                                "command" : "bash -xe /etc/cfn/scripts/watchmaker-install.sh",
-                                "env" :
-                                {
-                                  "AWS_DEFAULT_REGION" : { "Ref" : "AWS::Region" },
-                                  "AWS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt",
-                                  "REQUESTS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt"
-                                }
-                            }
-                        }
-                    },
-                    "watchmaker-launch" :
-                    {
-                        "commands" :
-                        {
-                            "10-watchmaker-launch" :
-                            {
-                                "command" :
-                                { "Fn::Join" : [ "", [
-                                    "watchmaker --log-level debug",
-                                    " --log-dir /var/log/watchmaker",
-                                    " --no-reboot",
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseWamConfig",
-                                            { "Fn::Join" : [ "", [
-                                                " --config \"",
-                                                { "Ref" : "WatchmakerConfig" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseEnvironment",
-                                            { "Fn::Join" : [ "", [
-                                                " --env \"",
-                                                { "Ref" : "WatchmakerEnvironment" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseOuPath",
-                                            { "Fn::Join" : [ "", [
-                                                " --ou-path \"",
-                                                { "Ref" : "WatchmakerOuPath" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseAdminGroups",
-                                            { "Fn::Join" : [ "", [
-                                                " --admin-groups \"",
-                                                { "Ref" : "WatchmakerAdminGroups" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseAdminUsers",
-                                            { "Fn::Join" : [ "", [
-                                                " --admin-users \"",
-                                                { "Ref" : "WatchmakerAdminUsers" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseS3Source",
-                                            " --s3-source",
-                                            ""
-                                        ]
-                                    }
-                                ]]}
-                            }
-                        }
-                    },
-                    "watchmaker-update" :
-                    {
-                        "commands" :
-                        {
-                            "10-watchmaker-update" :
-                            {
-                                "command" :
-                                { "Fn::Join" : [ "", [
-                                    "watchmaker --log-level debug",
-                                    " --log-dir /var/log/watchmaker",
-                                    " --salt-states None",
-                                    " --no-reboot",
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseWamConfig",
-                                            { "Fn::Join" : [ "", [
-                                                " --config \"",
-                                                { "Ref" : "WatchmakerConfig" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseEnvironment",
-                                            { "Fn::Join" : [ "", [
-                                                " --env \"",
-                                                { "Ref" : "WatchmakerEnvironment" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseOuPath",
-                                            { "Fn::Join" : [ "", [
-                                                " --ou-path \"",
-                                                { "Ref" : "WatchmakerOuPath" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseAdminGroups",
-                                            { "Fn::Join" : [ "", [
-                                                " --admin-groups \"",
-                                                { "Ref" : "WatchmakerAdminGroups" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseAdminUsers",
-                                            { "Fn::Join" : [ "", [
-                                                " --admin-users \"",
-                                                { "Ref" : "WatchmakerAdminUsers" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseS3Source",
-                                            " --s3-source",
-                                            ""
-                                        ]
-                                    }
-                                ]]}
-                            }
-                        }
-                    },
-                    "make-app" :
-                    {
-                        "commands" :
-                        {
-                            "05-get-appscript" :
-                            {
-                                "command" :
-                                { "Fn::Join" : [ "", [
-                                    "mkdir -p /etc/cfn/scripts &&",
-                                    " aws s3 cp ",
-                                    { "Ref" : "AppScriptUrl" },
-                                    " /etc/cfn/scripts/make-app",
-                                    " --region ",
-                                    { "Ref" : "AWS::Region" }, " &&",
-                                    " chown root:root /etc/cfn/scripts/make-app &&",
-                                    " chmod 700 /etc/cfn/scripts/make-app"
-                                ]]},
-                                "env" :
-                                {
-                                  "AWS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt",
-                                  "REQUESTS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt"
-                                }
-                            },
-                            "10-make-app" :
-                            {
-                                "command" :
-                                { "Fn::Join" : [ "", [
-                                    { "Ref" : "AppScriptShell" },
-                                    " /etc/cfn/scripts/make-app ",
-                                    { "Ref" : "AppScriptParams" }
-                                ]]},
-                                "env" :
-                                {
-                                  "AWS_DEFAULT_REGION" : { "Ref" : "AWS::Region" },
-                                  "AWS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt",
-                                  "REQUESTS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt"
-                                }
-                            }
-                        }
-                    },
-                    "finalize" :
-                    {
-                        "commands" :
-                        {
-                            "10-signal-success" :
-                            {
-                                "command" :
-                                { "Fn::Join" : [ "", [
-                                    "/opt/aws/bin/cfn-signal -e 0",
-                                    " --stack ", { "Ref" : "AWS::StackName" },
-                                    " --resource WatchmakerAutoScalingGroup",
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "AssignInstanceRole",
-                                            { "Fn::Join" : [ "", [
-                                                " --role ",
-                                                { "Ref" : "InstanceRole" }
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseCfnUrl",
-                                            { "Fn::Join" : [ "", [
-                                                " --url ",
-                                                { "Ref" : "CfnEndpointUrl" }
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    " --region ", { "Ref" : "AWS::Region"}, "\n"
-                                ]]},
-                                "ignoreErrors" : "true"
-                            }
-                        }
-                    },
-                    "reboot" :
-                    {
-                        "commands" :
-                        {
-                            "10-reboot" :
-                            {
-                                "command" : "shutdown -r +1 &"
-                            }
-                        }
-                    }
-                }
-            },
-            "Properties" :
-            {
-                "ImageId" : { "Ref" : "AmiId" },
-                "InstanceType" : { "Ref" : "InstanceType" },
-                "IamInstanceProfile" :
-                {
-                    "Fn::If" :
-                    [
-                        "AssignInstanceRole",
-                        { "Ref" : "InstanceRole" },
-                        { "Ref" : "AWS::NoValue" }
-                    ]
-                },
-                "AssociatePublicIpAddress" :
-                {
-                    "Fn::If" :
-                    [
-                        "AssignPublicIp",
-                        "true",
-                        "false"
-                    ]
-                },
-                "BlockDeviceMappings" :
-                [
-                    {
-                        "DeviceName" :
-                        { "Fn::Join" : [ "", [
-                            "/dev/",
-                            { "Fn::FindInMap" :
-                                [
-                                    "Distro2RootDevice",
-                                    { "Ref" : "AmiDistro" },
-                                    "DeviceName"
-                                ]
-                            }
-                        ]]},
-                        "Ebs" :
-                        {
-                            "VolumeType" : "gp2",
-                            "DeleteOnTermination" : "true"
-                        }
-                      },
-                      {
-                          "Fn::If" :
-                          [
-                              "CreateAppVolume",
-                              {
-                                  "DeviceName" : { "Ref" : "AppVolumeDevice" },
-                                  "Ebs" :
-                                  {
-                                      "VolumeSize" : { "Ref" : "AppVolumeSize" },
-                                      "VolumeType" : { "Ref" : "AppVolumeType" },
-                                      "DeleteOnTermination" : "true"
-                                  }
-                              },
-                              { "Ref" : "AWS::NoValue" }
-                          ]
-                      }
-                ],
-                "KeyName" :
-                {
-                    "Ref" : "KeyPairName"
-                },
-                "SecurityGroups" :
-                {
-                    "Ref" : "SecurityGroupIds"
-                },
-                "UserData" :
-                {
-                    "Fn::Base64" :
-                    { "Fn::Join" : [ "", [
-                        "Content-Type: multipart/mixed; boundary=\"===============3585321300151562773==\"\n",
-                        "MIME-Version: 1.0\n",
-                        "\n",
-
-                        "--===============3585321300151562773==\n",
-                        "Content-Type: text/cloud-config; charset=\"us-ascii\"\n",
-                        "MIME-Version: 1.0\n",
-                        "Content-Transfer-Encoding: 7bit\n",
-                        "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
-                        "\n",
-
-                        "#cloud-config\n",
-                        {
-                            "Fn::If" :
-                            [
-                                "CreateAppVolume",
-                                { "Fn::Join" : [ "", [
-                                    "bootcmd:\n",
-                                    "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
-                                    { "Ref" : "AppVolumeDevice" },
-                                    "\n",
-                                    "mounts:\n",
-                                    "- [ ",
-                                    { "Ref" : "AppVolumeDevice" }, ", ",
-                                    { "Ref" : "AppVolumeMountPath" },
-                                    " ]\n"
-                                ]]},
-                                { "Ref" : "AWS::NoValue" }
-                            ]
-                        },
-
-                        "\n",
-
-                        "--===============3585321300151562773==\n",
-                        "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
-                        "MIME-Version: 1.0\n",
-                        "Content-Transfer-Encoding: 7bit\n",
-                        "Content-Disposition: attachment; filename=\"script.sh\"\n",
-                        "\n",
-
-                        "#!/bin/bash -xe\n\n",
-
-                        "# CFN LaunchConfig Update Toggle: ",
-                        { "Ref" : "ToggleNewInstances" },
-                        "\n\n",
-
-                        "# Export cert bundle ENVs\n",
-                        "export AWS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
-                        "export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n\n",
-
-                        "# Get pip\n",
-                        "curl --silent --show-error --retry 5 -L ",
-                        { "Ref" : "CfnGetPipUrl" },
-                        " | python - --index-url=", { "Ref" : "PypiIndexUrl" }, "\n\n",
-
-                        "# Add pip to path\n",
-                        "hash pip 2> /dev/null || ",
-                        "PATH=\"${PATH}:/usr/local/bin\"", "\n\n",
-
-                        "# Upgrade pip and setuptools\n",
-                        "PYPI_URL=", { "Ref" : "PypiIndexUrl" }, "\n",
-                        "pip install",
-                        " --index-url=\"$PYPI_URL\"",
-                        " --upgrade pip setuptools\n\n",
-
-                        "# Fix python urllib3 warnings\n",
-                        "yum -y install gcc python-devel libffi-devel openssl-devel\n",
-                        "pip install",
-                        " --index-url=\"$PYPI_URL\"",
-                        " --upgrade pyopenssl ndg-httpsclient pyasn1\n\n",
-
-                        "# Get cfn utils\n",
-                        "pip install",
-                        " --index-url=\"$PYPI_URL\"",
-                        " --upgrade ",
-                        { "Ref" : "CfnBootstrapUtilsUrl" },
-                        "\n\n",
-
-                        "# Remove gcc now that it is no longer needed\n",
-                        "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
-
-                        "# Fixup cfn utils\n",
-                        "INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat ",
-                        "2> /dev/null || echo /usr/init/redhat)\n",
-                        "chmod 775 ${INITDIR}/cfn-hup\n",
-                        "ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
-                        "chkconfig --add cfn-hup\n",
-                        "chkconfig cfn-hup on\n",
-                        "mkdir -p /opt/aws/bin\n",
-                        "BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin ",
-                        "2> /dev/null || echo /usr/bin)\n",
-                        "for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup ",
-                        "cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
-                        "do\n",
-                        "    ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
-                        "    echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
-                        "done\n\n",
-
-                        "# Add cfn-signal to path\n",
-                        "hash cfn-signal 2> /dev/null || ",
-                        "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
-                        "\n\n",
-
-                        "# Execute cfn-init\n",
-                        "/opt/aws/bin/cfn-init -v -c launch",
-                        " --stack ", { "Ref" : "AWS::StackName" },
-                        " --resource WatchmakerLaunchConfig",
-                        {
-                            "Fn::If" :
-                            [
-                                "AssignInstanceRole",
-                                { "Fn::Join" : [ "", [
-                                    " --role ", { "Ref" : "InstanceRole" }
-                                ] ] },
-                                ""
-                            ]
-                        },
-                        {
-                            "Fn::If" :
-                            [
-                                "UseCfnUrl",
-                                { "Fn::Join" : [ "", [
-                                    " --url ", { "Ref" : "CfnEndpointUrl" }
-                                ] ] },
-                                ""
-                            ]
-                        },
-                        " --region ", { "Ref" : "AWS::Region" }, " ||",
-                        " ( echo 'ERROR: cfn-init failed! Aborting!';",
-                        " /opt/aws/bin/cfn-signal -e 1",
-                        "  --stack ", { "Ref" : "AWS::StackName" },
-                        "  --resource WatchmakerAutoScalingGroup",
-                        {
-                            "Fn::If" :
-                            [
-                                "AssignInstanceRole",
-                                { "Fn::Join" : [ "", [
-                                    " --role ", { "Ref" : "InstanceRole" }
-                                ] ] },
-                                ""
-                            ]
-                        },
-                        {
-                            "Fn::If" :
-                            [
-                                "UseCfnUrl",
-                                { "Fn::Join" : [ "", [
-                                    " --url ", { "Ref" : "CfnEndpointUrl" }
-                                ] ] },
-                                ""
-                            ]
-                        },
-                        "  --region ", { "Ref" : "AWS::Region"}, ";",
-                        " exit 1",
-                        " )\n\n",
-                        "--===============3585321300151562773==--"
-                    ] ] }
-                }
-            }
+        "t2.small": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "t2.medium": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "t2.large": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "t2.xlarge": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "m5.large": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/nvme1n1"
+        },
+        "m5.xlarge": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/nvme1n1"
+        },
+        "c5.large": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/nvme1n1"
+        },
+        "c5.xlarge": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/nvme1n1"
+        },
+        "m4.large": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "m4.xlarge": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "c4.large": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "c4.xlarge": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
         }
     }
+  },
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
+        {
+          "Label": {
+            "default": "EC2 Instance Configuration"
+          },
+          "Parameters": [
+            "AmiId",
+            "AmiDistro",
+            "InstanceType",
+            "InstanceRole",
+            "KeyPairName",
+            "NoPublicIp",
+            "NoReboot",
+            "NoUpdates",
+            "SecurityGroupIds"
+          ]
+        },
+        {
+          "Label": {
+            "default": "EC2 Watchmaker Configuration"
+          },
+          "Parameters": [
+            "PypiIndexUrl",
+            "WatchmakerConfig",
+            "WatchmakerEnvironment",
+            "WatchmakerOuPath",
+            "WatchmakerAdminGroups",
+            "WatchmakerAdminUsers",
+            "WatchmakerS3Source"
+          ]
+        },
+        {
+          "Label": {
+            "default": "EC2 Application Configuration"
+          },
+          "Parameters": [
+            "AppScriptUrl",
+            "AppScriptParams",
+            "AppScriptShell"
+          ]
+        },
+        {
+          "Label": {
+            "default": "EC2 Application EBS Volume"
+          },
+          "Parameters": [
+            "AppVolumeDevice",
+            "AppVolumeMountPath",
+            "AppVolumeSize",
+            "AppVolumeType"
+          ]
+        },
+        {
+          "Label": {
+            "default": "AutoScale Configuration"
+          },
+          "Parameters": [
+            "DesiredCapacity",
+            "MinCapacity",
+            "MaxCapacity"
+          ]
+        },
+        {
+          "Label": {
+            "default": "Network Configuration"
+          },
+          "Parameters": [
+            "SubnetIds"
+          ]
+        },
+        {
+          "Label": {
+            "default": "CloudFormation Configuration"
+          },
+          "Parameters": [
+            "CfnEndpointUrl",
+            "CfnGetPipUrl",
+            "CfnBootstrapUtilsUrl",
+            "ToggleCfnInitUpdate",
+            "ToggleNewInstances"
+          ]
+        }
+      ],
+      "ParameterLabels": {
+        "ToggleCfnInitUpdate": {
+          "default": "Force Cfn Init Update"
+        },
+        "ToggleNewInstances": {
+          "default": "Force New Instances"
+        }
+      }
+    }
+  },
+  "Parameters": {
+    "AmiDistro": {
+      "AllowedValues": [
+        "AmazonLinux",
+        "CentOS",
+        "RedHat"
+      ],
+      "Description": "Linux distro of the AMI",
+      "Type": "String"
+    },
+    "AmiId": {
+      "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
+      "Description": "ID of the AMI to launch",
+      "Type": "String"
+    },
+    "AppScriptParams": {
+      "Description": "Parameter string to pass to the application script. Ignored if \"AppScriptUrl\" is blank",
+      "Type": "String"
+    },
+    "AppScriptShell": {
+      "AllowedValues": [
+        "bash",
+        "python"
+      ],
+      "Default": "bash",
+      "Description": "Shell with which to execute the application script. Ignored if \"AppScriptUrl\" is blank",
+      "Type": "String"
+    },
+    "AppScriptUrl": {
+      "AllowedPattern": "^$|^s3://(.*)$",
+      "ConstraintDescription": "Must use an S3 URL (starts with \"s3://\")",
+      "Default": "",
+      "Description": "(Optional) S3 URL to the application script in an S3 bucket (s3://). Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
+      "Type": "String"
+    },
+    "AppVolumeDevice": {
+      "AllowedValues": [
+        "true",
+        "false"
+      ],
+      "Default": "false",
+      "Description": "Whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume",
+      "Type": "String"
+    },
+    "AppVolumeMountPath": {
+      "AllowedPattern": "/.*",
+      "Default": "/opt/data",
+      "Description": "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
+      "Type": "String"
+    },
+    "AppVolumeSize": {
+      "ConstraintDescription": "Must be between 1GB and 16384GB.",
+      "Default": "1",
+      "Description": "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+      "MaxValue": "16384",
+      "MinValue": "1",
+      "Type": "Number"
+    },
+    "AppVolumeType": {
+      "AllowedValues": [
+        "gp2",
+        "io1",
+        "sc1",
+        "st1",
+        "standard"
+      ],
+      "Default": "gp2",
+      "Description": "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+      "Type": "String"
+    },
+    "CfnBootstrapUtilsUrl": {
+      "AllowedPattern": "^http[s]?://.*\\.tar\\.gz$",
+      "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
+      "Description": "URL to aws-cfn-bootstrap-latest.tar.gz",
+      "Type": "String"
+    },
+    "CfnEndpointUrl": {
+      "AllowedPattern": "^$|^http[s]?://.*$",
+      "Default": "https://cloudformation.us-east-1.amazonaws.com",
+      "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
+      "Type": "String"
+    },
+    "CfnGetPipUrl": {
+      "AllowedPattern": "^http[s]?://.*\\.py$",
+      "Default": "https://bootstrap.pypa.io/get-pip.py",
+      "Description": "URL to get-pip.py",
+      "Type": "String"
+    },
+    "DesiredCapacity": {
+      "Default": "1",
+      "Description": "Desired number of instances in the Autoscaling Group",
+      "Type": "Number"
+    },
+    "InstanceRole": {
+      "Default": "",
+      "Description": "(Optional) IAM instance role to apply to the instance(s)",
+      "Type": "String"
+    },
+    "InstanceType": {
+      "AllowedValues": [
+        "t2.micro",
+        "t2.small",
+        "t2.medium",
+        "t2.large",
+        "t2.xlarge",
+        "m5.large",
+        "m5.xlarge",
+        "c5.large",
+        "c5.xlarge",
+        "m4.large",
+        "m4.xlarge",
+        "c4.large",
+        "c4.xlarge"
+      ],
+      "Default": "t2.micro",
+      "Description": "Amazon EC2 instance type",
+      "Type": "String"
+    },
+    "KeyPairName": {
+      "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
+      "Type": "AWS::EC2::KeyPair::KeyName"
+    },
+    "MaxCapacity": {
+      "Default": "2",
+      "Description": "Maximum number of instances in the Autoscaling Group",
+      "Type": "Number"
+    },
+    "MinCapacity": {
+      "Default": "1",
+      "Description": "Minimum number of instances in the Autoscaling Group",
+      "Type": "Number"
+    },
+    "NoPublicIp": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "true",
+      "Description": "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
+      "Type": "String"
+    },
+    "NoReboot": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "false",
+      "Description": "Controls whether to reboot the instance as the last step of cfn-init execution",
+      "Type": "String"
+    },
+    "NoUpdates": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "false",
+      "Description": "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
+      "Type": "String"
+    },
+    "PypiIndexUrl": {
+      "AllowedPattern": "^http[s]?://.*$",
+      "Default": "https://pypi.org/simple",
+      "Description": "URL to the PyPi Index",
+      "Type": "String"
+    },
+    "SecurityGroupIds": {
+      "Description": "List of security groups to apply to the instance(s)",
+      "Type": "List<AWS::EC2::SecurityGroup::Id>"
+    },
+    "SubnetIds": {
+      "Description": "List of subnets to associate to the Autoscaling Group",
+      "Type": "List<AWS::EC2::Subnet::Id>"
+    },
+    "ToggleCfnInitUpdate": {
+      "AllowedValues": [
+        "A",
+        "B"
+      ],
+      "Default": "A",
+      "Description": "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
+      "Type": "String"
+    },
+    "ToggleNewInstances": {
+      "AllowedValues": [
+        "A",
+        "B"
+      ],
+      "Default": "A",
+      "Description": "A/B toggle that forces a change to instance userdata, triggering new instances via the Autoscale update policy",
+      "Type": "String"
+    },
+    "WatchmakerAdminGroups": {
+      "Default": "",
+      "Description": "(Optional) Colon-separated list of domain groups that should have admin permissions on the EC2 instance",
+      "Type": "String"
+    },
+    "WatchmakerAdminUsers": {
+      "Default": "",
+      "Description": "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
+      "Type": "String"
+    },
+    "WatchmakerConfig": {
+      "AllowedPattern": "^$|^http[s]?://.*$",
+      "Default": "",
+      "Description": "(Optional) URL to a Watchmaker config file",
+      "Type": "String"
+    },
+    "WatchmakerEnvironment": {
+      "AllowedValues": [
+        "",
+        "dev",
+        "test",
+        "prod"
+      ],
+      "Default": "",
+      "Description": "Environment in which the instance is being deployed",
+      "Type": "String"
+    },
+    "WatchmakerOuPath": {
+      "AllowedPattern": "^$|^(OU=.+,)+(DC=.+)+$",
+      "Default": "",
+      "Description": "(Optional) DN of the OU to place the instance when joining a domain. If blank and \"WatchmakerEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"WatchmakerEnvironment\" is \"false\"",
+      "Type": "String"
+    },
+    "WatchmakerS3Source": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "false",
+      "Description": "Flag that tells watchmaker to use its instance role to retrieve watchmaker content from S3",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "WatchmakerAutoScalingGroup": {
+      "CreationPolicy": {
+        "ResourceSignal": {
+          "Count": { "Ref": "DesiredCapacity" },
+          "Timeout": "PT30M"
+        }
+      },
+      "Properties": {
+        "DesiredCapacity": { "Ref": "DesiredCapacity" },
+        "LaunchConfigurationName": { "Ref": "WatchmakerLaunchConfig" },
+        "MaxSize": { "Ref": "MaxCapacity" },
+        "MinSize": { "Ref": "MinCapacity" },
+        "Tags": [
+          {
+            "Key": "Name",
+            "PropagateAtLaunch": "true",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  { "Ref": "AWS::StackName" }
+                ]
+              ]
+            }
+          }
+        ],
+        "VPCZoneIdentifier": { "Ref": "SubnetIds" }
+      },
+      "Type": "AWS::AutoScaling::AutoScalingGroup",
+      "UpdatePolicy": {
+        "AutoScalingRollingUpdate": {
+          "MaxBatchSize": "2",
+          "MinInstancesInService": "1",
+          "PauseTime": "PT30M",
+          "WaitOnResourceSignals": "true"
+        }
+      }
+    },
+    "WatchmakerLaunchConfig": {
+      "Metadata": {
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "launch": [
+              "setup",
+              "watchmaker-install",
+              "watchmaker-launch",
+              {
+                "Fn::If": [
+                  "ExecuteAppScript",
+                  "make-app",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
+              "finalize",
+              {
+                "Fn::If": [
+                  "Reboot",
+                  "reboot",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              }
+            ],
+            "update": [
+              "setup",
+              {
+                "Fn::If": [
+                  "InstallUpdates",
+                  "install-updates",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
+              "watchmaker-install",
+              "watchmaker-update",
+              {
+                "Fn::If": [
+                  "ExecuteAppScript",
+                  "make-app",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
+              "finalize",
+              {
+                "Fn::If": [
+                  "Reboot",
+                  "reboot",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              }
+            ]
+          },
+          "finalize": {
+            "commands": {
+              "10-signal-success": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "/opt/aws/bin/cfn-signal -e 0",
+                      " --stack ",
+                      { "Ref": "AWS::StackName" },
+                      " --resource WatchmakerAutoScalingGroup",
+                      {
+                        "Fn::If": [
+                          "AssignInstanceRole",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --role ",
+                                { "Ref": "InstanceRole" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseCfnUrl",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --url ",
+                                { "Ref": "CfnEndpointUrl" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      " --region ",
+                      { "Ref": "AWS::Region" },
+                      "\n"
+                    ]
+                  ]
+                },
+                "ignoreErrors": "true"
+              }
+            }
+          },
+          "install-updates": {
+            "commands": {
+              "10-install-updates": {
+                "command": "yum -y update"
+              }
+            }
+          },
+          "make-app": {
+            "commands": {
+              "05-get-appscript": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "mkdir -p /etc/cfn/scripts &&",
+                      " aws s3 cp ",
+                      { "Ref": "AppScriptUrl" },
+                      " /etc/cfn/scripts/make-app",
+                      " --region ",
+                      { "Ref": "AWS::Region" },
+                      " &&",
+                      " chown root:root /etc/cfn/scripts/make-app &&",
+                      " chmod 700 /etc/cfn/scripts/make-app"
+                    ]
+                  ]
+                },
+                "env": {
+                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
+                  "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
+                }
+              },
+              "10-make-app": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      { "Ref": "AppScriptShell" },
+                      " /etc/cfn/scripts/make-app ",
+                      { "Ref": "AppScriptParams" }
+                    ]
+                  ]
+                },
+                "env": {
+                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
+                  "AWS_DEFAULT_REGION": { "Ref": "AWS::Region" },
+                  "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
+                }
+              }
+            }
+          },
+          "reboot": {
+            "commands": {
+              "10-reboot": {
+                "command": "shutdown -r +1 &"
+              }
+            }
+          },
+          "setup": {
+            "files": {
+              "/etc/cfn/cfn-hup.conf": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "[main]\n",
+                      "stack=",
+                      { "Ref": "AWS::StackId" },
+                      "\n",
+                      "region=",
+                      { "Ref": "AWS::Region" },
+                      "\n",
+                      {
+                        "Fn::If": [
+                          "AssignInstanceRole",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "role=",
+                                { "Ref": "InstanceRole" },
+                                "\n"
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseCfnUrl",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "url=",
+                                { "Ref": "CfnEndpointUrl" },
+                                "\n"
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      "interval=1",
+                      "\n",
+                      "verbose=true",
+                      "\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000400",
+                "owner": "root"
+              },
+              "/etc/cfn/hooks.d/cfn-auto-reloader.conf": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "[cfn-auto-reloader-hook]\n",
+                      "triggers=post.update\n",
+                      "path=Resources.WatchmakerLaunchConfig.Metadata\n",
+                      "action=/opt/aws/bin/cfn-init -v -c update",
+                      " --stack ",
+                      { "Ref": "AWS::StackName" },
+                      " --resource WatchmakerLaunchConfig",
+                      {
+                        "Fn::If": [
+                          "AssignInstanceRole",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --role ",
+                                { "Ref": "InstanceRole" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseCfnUrl",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --url ",
+                                { "Ref": "CfnEndpointUrl" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      " --region ",
+                      { "Ref": "AWS::Region" },
+                      "\n",
+                      "runas=root\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000400",
+                "owner": "root"
+              },
+              "/etc/cfn/scripts/watchmaker-install.sh": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "#!/bin/bash\n\n",
+                      "PYPI_URL=",
+                      { "Ref": "PypiIndexUrl" },
+                      "\n",
+                      "pip install --index-url=\"$PYPI_URL\" wheel==0.29.0\n",
+                      "pip install",
+                      " --index-url=\"$PYPI_URL\"",
+                      " --upgrade pip setuptools boto3 watchmaker\n\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000700",
+                "owner": "root"
+              }
+            },
+            "services": {
+              "sysvinit": {
+                "cfn-hup": {
+                  "enabled": "true",
+                  "ensureRunning": "true",
+                  "files": [
+                    "/etc/cfn/cfn-hup.conf",
+                    "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
+                  ]
+                }
+              }
+            }
+          },
+          "watchmaker-install": {
+            "commands": {
+              "10-watchmaker-install": {
+                "command": "bash -xe /etc/cfn/scripts/watchmaker-install.sh",
+                "env": {
+                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
+                  "AWS_DEFAULT_REGION": { "Ref": "AWS::Region" },
+                  "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
+                }
+              }
+            }
+          },
+          "watchmaker-launch": {
+            "commands": {
+              "10-watchmaker-launch": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "watchmaker --log-level debug",
+                      " --log-dir /var/log/watchmaker",
+                      " --no-reboot",
+                      {
+                        "Fn::If": [
+                          "UseWamConfig",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --config \"",
+                                { "Ref": "WatchmakerConfig" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseEnvironment",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --env \"",
+                                { "Ref": "WatchmakerEnvironment" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseOuPath",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --ou-path \"",
+                                { "Ref": "WatchmakerOuPath" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminGroups",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-groups \"",
+                                { "Ref": "WatchmakerAdminGroups" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminUsers",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-users \"",
+                                { "Ref": "WatchmakerAdminUsers" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseS3Source",
+                          " --s3-source",
+                          ""
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              }
+            }
+          },
+          "watchmaker-update": {
+            "commands": {
+              "10-watchmaker-update": {
+                "command": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "watchmaker --log-level debug",
+                      " --log-dir /var/log/watchmaker",
+                      " --salt-states None",
+                      " --no-reboot",
+                      {
+                        "Fn::If": [
+                          "UseWamConfig",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --config \"",
+                                { "Ref": "WatchmakerConfig" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseEnvironment",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --env \"",
+                                { "Ref": "WatchmakerEnvironment" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseOuPath",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --ou-path \"",
+                                { "Ref": "WatchmakerOuPath" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminGroups",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-groups \"",
+                                { "Ref": "WatchmakerAdminGroups" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminUsers",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-users \"",
+                                { "Ref": "WatchmakerAdminUsers" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseS3Source",
+                          " --s3-source",
+                          ""
+                        ]
+                      }
+                    ]
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "ToggleCfnInitUpdate": { "Ref": "ToggleCfnInitUpdate" }
+      },
+      "Properties": {
+        "AssociatePublicIpAddress": {
+          "Fn::If": [
+            "AssignPublicIp",
+            "true",
+            "false"
+          ]
+        },
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": {
+              "Fn::Join": [
+                "",
+                [
+                  "/dev/",
+                  {
+                    "Fn::FindInMap": [
+                      "Distro2RootDevice",
+                      { "Ref": "AmiDistro" },
+                      "DeviceName"
+                    ]
+                  }
+                ]
+              ]
+            },
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeType": "gp2"
+            }
+          },
+          {
+            "Fn::If": [
+              "CreateAppVolume",
+              {
+                "DeviceName": {
+                  "Fn::FindInMap": [
+                    "InstanceTypeCapabilities",
+                    { "Ref": "InstanceType" },
+                    "ExternDeviceName"
+                  ]
+                },
+                "Ebs": {
+                  "DeleteOnTermination": "true",
+                  "VolumeSize": { "Ref": "AppVolumeSize" },
+                  "VolumeType": { "Ref": "AppVolumeType" }
+                }
+              },
+              { "Ref": "AWS::NoValue" }
+            ]
+          }
+        ],
+        "IamInstanceProfile": {
+          "Fn::If": [
+            "AssignInstanceRole",
+            { "Ref": "InstanceRole" },
+            { "Ref": "AWS::NoValue" }
+          ]
+        },
+        "ImageId": { "Ref": "AmiId" },
+        "InstanceType": { "Ref": "InstanceType" },
+        "KeyName": { "Ref": "KeyPairName" },
+        "SecurityGroups": { "Ref": "SecurityGroupIds" },
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
+              [
+                "Content-Type: multipart/mixed; boundary=\"===============3585321300151562773==\"\n",
+                "MIME-Version: 1.0\n",
+                "\n",
+                "--===============3585321300151562773==\n",
+                "Content-Type: text/cloud-config; charset=\"us-ascii\"\n",
+                "MIME-Version: 1.0\n",
+                "Content-Transfer-Encoding: 7bit\n",
+                "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
+                "\n",
+                "#cloud-config\n",
+                {
+                  "Fn::If": [
+                    "CreateAppVolume",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "bootcmd:\n",
+                          "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
+                          {
+                            "Fn::FindInMap": [
+                              "InstanceTypeCapabilities",
+                              { "Ref": "InstanceType" },
+                              "InternDeviceName"
+                            ]
+                          },
+                          "\n",
+                          "mounts:\n",
+                          "- [ ",
+                          {
+                            "Fn::FindInMap": [
+                              "InstanceTypeCapabilities",
+                              { "Ref": "InstanceType" },
+                              "InternDeviceName"
+                            ]
+                          },
+                          ", ",
+                          { "Ref": "AppVolumeMountPath" },
+                          " ]\n"
+                        ]
+                      ]
+                    },
+                    { "Ref": "AWS::NoValue" }
+                  ]
+                },
+                "\n",
+                "--===============3585321300151562773==\n",
+                "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
+                "MIME-Version: 1.0\n",
+                "Content-Transfer-Encoding: 7bit\n",
+                "Content-Disposition: attachment; filename=\"script.sh\"\n",
+                "\n",
+                "#!/bin/bash -xe\n\n",
+                "# CFN LaunchConfig Update Toggle: ",
+                { "Ref": "ToggleNewInstances" },
+                "\n\n",
+                "# Export cert bundle ENVs\n",
+                "export AWS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
+                "export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n\n",
+                "# Get pip\n",
+                "curl --silent --show-error --retry 5 -L ",
+                { "Ref": "CfnGetPipUrl" },
+                " | python - --index-url=",
+                { "Ref": "PypiIndexUrl" },
+                "\n\n",
+                "# Add pip to path\n",
+                "hash pip 2> /dev/null || ",
+                "PATH=\"${PATH}:/usr/local/bin\"",
+                "\n\n",
+                "# Upgrade pip and setuptools\n",
+                "PYPI_URL=",
+                { "Ref": "PypiIndexUrl" },
+                "\n",
+                "pip install",
+                " --index-url=\"$PYPI_URL\"",
+                " --upgrade pip setuptools\n\n",
+                "# Fix python urllib3 warnings\n",
+                "yum -y install gcc python-devel libffi-devel openssl-devel\n",
+                "pip install",
+                " --index-url=\"$PYPI_URL\"",
+                " --upgrade pyopenssl ndg-httpsclient pyasn1\n\n",
+                "# Get cfn utils\n",
+                "pip install",
+                " --index-url=\"$PYPI_URL\"",
+                " --upgrade ",
+                { "Ref": "CfnBootstrapUtilsUrl" },
+                "\n\n",
+                "# Remove gcc now that it is no longer needed\n",
+                "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
+                "# Fixup cfn utils\n",
+                "INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat ",
+                "2> /dev/null || echo /usr/init/redhat)\n",
+                "chmod 775 ${INITDIR}/cfn-hup\n",
+                "ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
+                "chkconfig --add cfn-hup\n",
+                "chkconfig cfn-hup on\n",
+                "mkdir -p /opt/aws/bin\n",
+                "BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin ",
+                "2> /dev/null || echo /usr/bin)\n",
+                "for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup ",
+                "cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
+                "do\n",
+                "  ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
+                "  echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
+                "done\n\n",
+                "# Add cfn-signal to path\n",
+                "hash cfn-signal 2> /dev/null || ",
+                "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
+                "\n\n",
+                "# Execute cfn-init\n",
+                "/opt/aws/bin/cfn-init -v -c launch",
+                " --stack ",
+                { "Ref": "AWS::StackName" },
+                " --resource WatchmakerLaunchConfig",
+                {
+                  "Fn::If": [
+                    "AssignInstanceRole",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --role ",
+                          { "Ref": "InstanceRole" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                {
+                  "Fn::If": [
+                    "UseCfnUrl",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --url ",
+                          { "Ref": "CfnEndpointUrl" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                " --region ",
+                { "Ref": "AWS::Region" },
+                " ||",
+                " ( echo 'ERROR: cfn-init failed! Aborting!';",
+                " /opt/aws/bin/cfn-signal -e 1",
+                "  --stack ",
+                { "Ref": "AWS::StackName" },
+                "  --resource WatchmakerAutoScalingGroup",
+                {
+                  "Fn::If": [
+                    "AssignInstanceRole",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --role ",
+                          { "Ref": "InstanceRole" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                {
+                  "Fn::If": [
+                    "UseCfnUrl",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --url ",
+                          { "Ref": "CfnEndpointUrl" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                "  --region ",
+                { "Ref": "AWS::Region" },
+                ";",
+                " exit 1",
+                " )\n\n",
+                "--===============3585321300151562773==--"
+              ]
+            ]
+          }
+        }
+      },
+      "Type": "AWS::AutoScaling::LaunchConfiguration"
+    }
+  }
 }

--- a/docs/files/templates/lx-autoscale/watchmaker-lx-autoscale.tf
+++ b/docs/files/templates/lx-autoscale/watchmaker-lx-autoscale.tf
@@ -36,8 +36,8 @@ variable "AppScriptUrl" {
 
 variable "AppVolumeDevice" {
   type        = "string"
-  description = "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume"
-  default     = ""
+  description = "Whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume"
+  default     = "false"
 }
 
 variable "AppVolumeMountPath" {

--- a/docs/files/templates/lx-instance/watchmaker-lx-instance.template
+++ b/docs/files/templates/lx-instance/watchmaker-lx-instance.template
@@ -1,352 +1,104 @@
 {
   "AWSTemplateFormatVersion": "2010-09-09",
+  "Conditions": {
+    "AssignInstanceRole": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "InstanceRole" }, "" ] }
+      ]
+    },
+    "AssignPublicIp": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "NoPublicIp" }, "true" ] }
+      ]
+    },
+    "AssignStaticPrivateIp": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "PrivateIp" }, "" ] }
+      ]
+    },
+    "CreateAppVolume": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "" ] }
+      ]
+    },
+    "ExecuteAppScript": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "AppScriptUrl" }, "" ] }
+      ]
+    },
+    "InstallUpdates": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "NoUpdates" }, "true" ] }
+      ]
+    },
+    "Reboot": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "NoReboot" }, "true" ] }
+      ]
+    },
+    "UseAdminGroups": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerAdminGroups" }, "" ] }
+      ]
+    },
+    "UseAdminUsers": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerAdminUsers" }, "" ] }
+      ]
+    },
+    "UseCfnUrl": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "CfnEndpointUrl" }, "" ] }
+      ]
+    },
+    "UseComputerName": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerComputerName" }, "" ] }
+      ]
+    },
+    "UseEnvironment": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerEnvironment" }, "" ] }
+      ]
+    },
+    "UseOuPath": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerOuPath" }, "" ] }
+      ]
+    },
+    "UseS3Source": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerS3Source" }, "false" ] }
+      ]
+    },
+    "UseWamConfig": {
+      "Fn::Not": [
+        { "Fn::Equals": [ { "Ref": "WatchmakerConfig" }, "" ] }
+      ]
+    }
+  },
   "Description": "This template deploys a Linux instance using Watchmaker, which applies the DISA STIG.",
-  "Parameters":
-  {
-    "AmiId":
-    {
-      "Description": "ID of the AMI to launch",
-      "Type": "String",
-      "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$"
-    },
-    "AmiDistro":
-    {
-      "Description": "Linux distro of the AMI",
-      "Type": "String",
-      "AllowedValues":
-      [
-        "AmazonLinux",
-        "CentOS",
-        "RedHat"
-      ]
-    },
-    "AppScriptParams":
-    {
-      "Description": "Parameter string to pass to the application script. Ignored if \"AppScriptUrl\" is blank",
-      "Type": "String"
-    },
-    "AppScriptShell":
-    {
-      "Description": "Shell with which to execute the application script. Ignored if \"AppScriptUrl\" is blank",
-      "Type": "String",
-      "Default": "bash",
-      "AllowedValues":
-      [
-        "bash",
-        "python"
-      ]
-    },
-    "AppScriptUrl":
-    {
-      "Description": "(Optional) S3 URL to the application script in an S3 bucket (s3://). Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
-      "Type": "String",
-      "Default": "",
-      "AllowedPattern": "^$|^s3://(.*)$",
-      "ConstraintDescription": "Must use an S3 URL (starts with \"s3://\")"
-    },
-    "AppVolumeDevice":
-    {
-      "Description": "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume",
-      "Type": "String",
-      "Default": "",
-      "AllowedValues":
-      [
-        "",
-        "/dev/xvdf",
-        "/dev/xvdg",
-        "/dev/xvdh",
-        "/dev/xvdi",
-        "/dev/xvdj"
-      ]
-    },
-    "AppVolumeMountPath":
-    {
-      "Description": "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
-      "Type": "String",
-      "Default": "/opt/data",
-      "AllowedPattern": "/.*"
-    },
-    "AppVolumeType":
-    {
-      "Description": "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
-      "Type": "String",
-      "Default": "gp2",
-      "AllowedValues":
-      [
-        "gp2",
-        "io1",
-        "sc1",
-        "st1",
-        "standard"
-      ]
-    },
-    "AppVolumeSize":
-    {
-      "Description": "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
-      "Type": "Number",
-      "Default": "1",
-      "MinValue": "1",
-      "MaxValue": "16384",
-      "ConstraintDescription": "Must be between 1GB and 16384GB."
-    },
-    "KeyPairName":
-    {
-      "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
-      "Type": "AWS::EC2::KeyPair::KeyName"
-    },
-    "InstanceType":
-    {
-      "Description": "Amazon EC2 instance type",
-      "Type": "String",
-      "Default": "t2.micro",
-      "AllowedValues":
-      [
-        "t2.micro",
-        "t2.small",
-        "t2.medium",
-        "t2.large",
-        "c4.large",
-        "c4.xlarge",
-        "m4.large",
-        "m4.xlarge"
-      ]
-    },
-    "InstanceRole":
-    {
-      "Description": "(Optional) IAM instance role to apply to the instance",
-      "Type": "String",
-      "Default": ""
-    },
-    "PrivateIp":
-    {
-      "Description": "(Optional) Set a static, primary private IP. Leave blank to auto-select a free IP",
-      "Type": "String",
-      "Default": ""
-    },
-    "NoPublicIp":
-    {
-      "Description": "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
-      "Type": "String",
-      "Default": "true",
-      "AllowedValues":
-      [
-        "false",
-        "true"
-      ]
-    },
-    "NoReboot":
-    {
-      "Description": "Controls whether to reboot the instance as the last step of cfn-init execution",
-      "Type": "String",
-      "Default": "false",
-      "AllowedValues":
-      [
-        "false",
-        "true"
-      ]
-    },
-    "NoUpdates":
-    {
-      "Description": "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
-      "Type": "String",
-      "Default": "false",
-      "AllowedValues":
-      [
-        "false",
-        "true"
-      ]
-    },
-    "SecurityGroupIds":
-    {
-      "Description": "List of security groups to apply to the instance",
-      "Type": "List<AWS::EC2::SecurityGroup::Id>"
-    },
-    "SubnetId":
-    {
-      "Type": "AWS::EC2::Subnet::Id",
-      "Description": "ID of the subnet to assign to the instance"
-    },
-    "PypiIndexUrl":
-    {
-      "Description": "URL to the PyPi Index",
-      "Type": "String",
-      "Default": "https://pypi.org/simple",
-      "AllowedPattern": "^http[s]?://.*$"
-    },
-    "WatchmakerConfig":
-    {
-      "Description": "(Optional) URL to a Watchmaker config file",
-      "Type": "String",
-      "Default": "",
-      "AllowedPattern": "^$|^http[s]?://.*$"
-    },
-    "WatchmakerEnvironment":
-    {
-      "Description": "Environment in which the instance is being deployed",
-      "Type": "String",
-      "Default": "",
-      "AllowedValues":
-      [
-        "",
-        "dev",
-        "test",
-        "prod"
-      ]
-    },
-    "WatchmakerOuPath":
-    {
-      "Description": "(Optional) DN of the OU to place the instance when joining a domain. If blank and \"WatchmakerEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"WatchmakerEnvironment\" is \"false\"",
-      "Type": "String",
-      "Default": "",
-      "AllowedPattern": "^$|^(OU=.+,)+(DC=.+)+$"
-    },
-    "WatchmakerComputerName":
-    {
-      "Description": "(Optional) Sets the hostname/computername within the OS",
-      "Type": "String",
-      "Default": ""
-    },
-    "WatchmakerAdminGroups":
-    {
-      "Description": "(Optional) Colon-separated list of domain groups that should have admin permissions on the EC2 instance",
-      "Type": "String",
-      "Default": ""
-    },
-    "WatchmakerAdminUsers":
-    {
-      "Description": "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
-      "Type": "String",
-      "Default": ""
-    },
-    "WatchmakerS3Source":
-    {
-      "Description": "Flag that tells watchmaker to use its instance role to retrieve watchmaker content from S3",
-      "Type": "String",
-      "Default": "false",
-      "AllowedValues":
-      [
-        "false",
-        "true"
-      ]
-    },
-    "CfnEndpointUrl":
-    {
-      "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
-      "Type": "String",
-      "Default": "https://cloudformation.us-east-1.amazonaws.com",
-      "AllowedPattern": "^$|^http[s]?://.*$"
-    },
-    "CfnGetPipUrl":
-    {
-      "Description": "URL to get-pip.py",
-      "Type": "String",
-      "Default": "https://bootstrap.pypa.io/get-pip.py",
-      "AllowedPattern": "^http[s]?://.*\\.py$"
-    },
-    "CfnBootstrapUtilsUrl":
-    {
-      "Description": "URL to aws-cfn-bootstrap-latest.tar.gz",
-      "Type": "String",
-      "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-      "AllowedPattern": "^http[s]?://.*\\.tar\\.gz$"
-    },
-    "ToggleCfnInitUpdate":
-    {
-      "Description": "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
-      "Type": "String",
-      "Default": "A",
-      "AllowedValues":
-      [
-        "A",
-        "B"
-      ]
+  "Mappings": {
+    "Distro2RootDevice": {
+      "AmazonLinux": {
+        "DeviceName": "xvda"
+      },
+      "CentOS": {
+        "DeviceName": "sda1"
+      },
+      "RedHat": {
+        "DeviceName": "sda1"
+      }
     }
   },
-  "Conditions":
-  {
-    "ExecuteAppScript":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "AppScriptUrl" }, "" ] } ]
-    },
-    "CreateAppVolume":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "" ] } ]
-    },
-    "UseWamConfig":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerConfig" }, "" ] } ]
-    },
-    "UseOuPath":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerOuPath" }, "" ] } ]
-    },
-    "UseComputerName":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerComputerName" }, "" ] } ]
-    },
-    "UseAdminGroups":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerAdminGroups" }, "" ] } ]
-    },
-    "UseAdminUsers":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerAdminUsers" }, "" ] } ]
-    },
-    "UseS3Source":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerS3Source" }, "false" ] } ]
-    },
-    "UseEnvironment":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerEnvironment" }, "" ] } ]
-    },
-    "UseCfnUrl":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "CfnEndpointUrl" }, "" ] } ]
-    },
-    "InstallUpdates":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "NoUpdates" }, "true" ] } ]
-    },
-    "Reboot":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "NoReboot" }, "true" ] } ]
-    },
-    "AssignInstanceRole":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "InstanceRole" }, "" ] } ]
-    },
-    "AssignStaticPrivateIp":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "PrivateIp" }, "" ] } ]
-    },
-    "AssignPublicIp":
-    {
-      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "NoPublicIp" }, "true" ] } ]
-    }
-  },
-  "Mappings":
-  {
-    "Distro2RootDevice":
-    {
-      "AmazonLinux": { "DeviceName": "xvda" },
-      "RedHat": { "DeviceName": "sda1" },
-      "CentOS": { "DeviceName": "sda1" }
-    }
-  },
-  "Metadata":
-  {
-    "AWS::CloudFormation::Interface":
-    {
-      "ParameterGroups":
-      [
+  "Metadata": {
+    "AWS::CloudFormation::Interface": {
+      "ParameterGroups": [
         {
-          "Label":
-          {
+          "Label": {
             "default": "EC2 Instance Configuration"
           },
-          "Parameters":
-          [
+          "Parameters": [
             "AmiId",
             "AmiDistro",
             "InstanceType",
@@ -359,12 +111,10 @@
           ]
         },
         {
-          "Label":
-          {
+          "Label": {
             "default": "EC2 Watchmaker Configuration"
           },
-          "Parameters":
-          [
+          "Parameters": [
             "PypiIndexUrl",
             "WatchmakerConfig",
             "WatchmakerEnvironment",
@@ -376,24 +126,20 @@
           ]
         },
         {
-          "Label":
-          {
+          "Label": {
             "default": "EC2 Application Configuration"
           },
-          "Parameters":
-          [
+          "Parameters": [
             "AppScriptUrl",
             "AppScriptParams",
             "AppScriptShell"
           ]
         },
         {
-          "Label":
-          {
+          "Label": {
             "default": "EC2 Application EBS Volume"
           },
-          "Parameters":
-          [
+          "Parameters": [
             "AppVolumeDevice",
             "AppVolumeMountPath",
             "AppVolumeSize",
@@ -401,23 +147,19 @@
           ]
         },
         {
-          "Label":
-          {
+          "Label": {
             "default": "Network Configuration"
           },
-          "Parameters":
-          [
+          "Parameters": [
             "PrivateIp",
             "SubnetId"
           ]
         },
         {
-          "Label":
-          {
+          "Label": {
             "default": "CloudFormation Configuration"
           },
-          "Parameters":
-          [
+          "Parameters": [
             "CfnEndpointUrl",
             "CfnGetPipUrl",
             "CfnBootstrapUtilsUrl",
@@ -425,42 +167,255 @@
           ]
         }
       ],
-      "ParameterLabels":
-      {
-        "ToggleCfnInitUpdate":
-        {
+      "ParameterLabels": {
+        "ToggleCfnInitUpdate": {
           "default": "Force Cfn Init Update"
         }
       }
     }
   },
-  "Resources":
-  {
-    "WatchmakerInstance":
-    {
-      "Type": "AWS::EC2::Instance",
-      "CreationPolicy":
-      {
-        "ResourceSignal":
-        {
+  "Outputs": {
+    "WatchmakerInstanceId": {
+      "Description": "Instance ID",
+      "Value": { "Ref": "WatchmakerInstance" }
+    }
+  },
+  "Parameters": {
+    "AmiDistro": {
+      "AllowedValues": [
+        "AmazonLinux",
+        "CentOS",
+        "RedHat"
+      ],
+      "Description": "Linux distro of the AMI",
+      "Type": "String"
+    },
+    "AmiId": {
+      "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$",
+      "Description": "ID of the AMI to launch",
+      "Type": "String"
+    },
+    "AppScriptParams": {
+      "Description": "Parameter string to pass to the application script. Ignored if \"AppScriptUrl\" is blank",
+      "Type": "String"
+    },
+    "AppScriptShell": {
+      "AllowedValues": [
+        "bash",
+        "python"
+      ],
+      "Default": "bash",
+      "Description": "Shell with which to execute the application script. Ignored if \"AppScriptUrl\" is blank",
+      "Type": "String"
+    },
+    "AppScriptUrl": {
+      "AllowedPattern": "^$|^s3://(.*)$",
+      "ConstraintDescription": "Must use an S3 URL (starts with \"s3://\")",
+      "Default": "",
+      "Description": "(Optional) S3 URL to the application script in an S3 bucket (s3://). Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
+      "Type": "String"
+    },
+    "AppVolumeDevice": {
+      "AllowedValues": [
+        "",
+        "/dev/xvdf",
+        "/dev/xvdg",
+        "/dev/xvdh",
+        "/dev/xvdi",
+        "/dev/xvdj"
+      ],
+      "Default": "",
+      "Description": "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume",
+      "Type": "String"
+    },
+    "AppVolumeMountPath": {
+      "AllowedPattern": "/.*",
+      "Default": "/opt/data",
+      "Description": "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
+      "Type": "String"
+    },
+    "AppVolumeSize": {
+      "ConstraintDescription": "Must be between 1GB and 16384GB.",
+      "Default": "1",
+      "Description": "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+      "MaxValue": "16384",
+      "MinValue": "1",
+      "Type": "Number"
+    },
+    "AppVolumeType": {
+      "AllowedValues": [
+        "gp2",
+        "io1",
+        "sc1",
+        "st1",
+        "standard"
+      ],
+      "Default": "gp2",
+      "Description": "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+      "Type": "String"
+    },
+    "CfnBootstrapUtilsUrl": {
+      "AllowedPattern": "^http[s]?://.*\\.tar\\.gz$",
+      "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
+      "Description": "URL to aws-cfn-bootstrap-latest.tar.gz",
+      "Type": "String"
+    },
+    "CfnEndpointUrl": {
+      "AllowedPattern": "^$|^http[s]?://.*$",
+      "Default": "https://cloudformation.us-east-1.amazonaws.com",
+      "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
+      "Type": "String"
+    },
+    "CfnGetPipUrl": {
+      "AllowedPattern": "^http[s]?://.*\\.py$",
+      "Default": "https://bootstrap.pypa.io/get-pip.py",
+      "Description": "URL to get-pip.py",
+      "Type": "String"
+    },
+    "InstanceRole": {
+      "Default": "",
+      "Description": "(Optional) IAM instance role to apply to the instance",
+      "Type": "String"
+    },
+    "InstanceType": {
+      "AllowedValues": [
+        "t2.micro",
+        "t2.small",
+        "t2.medium",
+        "t2.large",
+        "c4.large",
+        "c4.xlarge",
+        "m4.large",
+        "m4.xlarge"
+      ],
+      "Default": "t2.micro",
+      "Description": "Amazon EC2 instance type",
+      "Type": "String"
+    },
+    "KeyPairName": {
+      "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
+      "Type": "AWS::EC2::KeyPair::KeyName"
+    },
+    "NoPublicIp": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "true",
+      "Description": "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
+      "Type": "String"
+    },
+    "NoReboot": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "false",
+      "Description": "Controls whether to reboot the instance as the last step of cfn-init execution",
+      "Type": "String"
+    },
+    "NoUpdates": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "false",
+      "Description": "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
+      "Type": "String"
+    },
+    "PrivateIp": {
+      "Default": "",
+      "Description": "(Optional) Set a static, primary private IP. Leave blank to auto-select a free IP",
+      "Type": "String"
+    },
+    "PypiIndexUrl": {
+      "AllowedPattern": "^http[s]?://.*$",
+      "Default": "https://pypi.org/simple",
+      "Description": "URL to the PyPi Index",
+      "Type": "String"
+    },
+    "SecurityGroupIds": {
+      "Description": "List of security groups to apply to the instance",
+      "Type": "List<AWS::EC2::SecurityGroup::Id>"
+    },
+    "SubnetId": {
+      "Description": "ID of the subnet to assign to the instance",
+      "Type": "AWS::EC2::Subnet::Id"
+    },
+    "ToggleCfnInitUpdate": {
+      "AllowedValues": [
+        "A",
+        "B"
+      ],
+      "Default": "A",
+      "Description": "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
+      "Type": "String"
+    },
+    "WatchmakerAdminGroups": {
+      "Default": "",
+      "Description": "(Optional) Colon-separated list of domain groups that should have admin permissions on the EC2 instance",
+      "Type": "String"
+    },
+    "WatchmakerAdminUsers": {
+      "Default": "",
+      "Description": "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
+      "Type": "String"
+    },
+    "WatchmakerComputerName": {
+      "Default": "",
+      "Description": "(Optional) Sets the hostname/computername within the OS",
+      "Type": "String"
+    },
+    "WatchmakerConfig": {
+      "AllowedPattern": "^$|^http[s]?://.*$",
+      "Default": "",
+      "Description": "(Optional) URL to a Watchmaker config file",
+      "Type": "String"
+    },
+    "WatchmakerEnvironment": {
+      "AllowedValues": [
+        "",
+        "dev",
+        "test",
+        "prod"
+      ],
+      "Default": "",
+      "Description": "Environment in which the instance is being deployed",
+      "Type": "String"
+    },
+    "WatchmakerOuPath": {
+      "AllowedPattern": "^$|^(OU=.+,)+(DC=.+)+$",
+      "Default": "",
+      "Description": "(Optional) DN of the OU to place the instance when joining a domain. If blank and \"WatchmakerEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"WatchmakerEnvironment\" is \"false\"",
+      "Type": "String"
+    },
+    "WatchmakerS3Source": {
+      "AllowedValues": [
+        "false",
+        "true"
+      ],
+      "Default": "false",
+      "Description": "Flag that tells watchmaker to use its instance role to retrieve watchmaker content from S3",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "WatchmakerInstance": {
+      "CreationPolicy": {
+        "ResourceSignal": {
           "Count": "1",
           "Timeout": "PT30M"
         }
       },
       "Metadata": {
-        "ToggleCfnInitUpdate": { "Ref": "ToggleCfnInitUpdate" },
-        "AWS::CloudFormation::Init":
-        {
-          "configSets":
-          {
-            "launch":
-            [
+        "AWS::CloudFormation::Init": {
+          "configSets": {
+            "launch": [
               "setup",
               "watchmaker-install",
               "watchmaker-launch",
               {
-                "Fn::If":
-                [
+                "Fn::If": [
                   "ExecuteAppScript",
                   "make-app",
                   { "Ref": "AWS::NoValue" }
@@ -468,20 +423,17 @@
               },
               "finalize",
               {
-                "Fn::If":
-                [
+                "Fn::If": [
                   "Reboot",
                   "reboot",
                   { "Ref": "AWS::NoValue" }
                 ]
               }
             ],
-            "update":
-            [
+            "update": [
               "setup",
               {
-                "Fn::If":
-                [
+                "Fn::If": [
                   "InstallUpdates",
                   "install-updates",
                   { "Ref": "AWS::NoValue" }
@@ -490,8 +442,7 @@
               "watchmaker-install",
               "watchmaker-update",
               {
-                "Fn::If":
-                [
+                "Fn::If": [
                   "ExecuteAppScript",
                   "make-app",
                   { "Ref": "AWS::NoValue" }
@@ -499,8 +450,7 @@
               },
               "finalize",
               {
-                "Fn::If":
-                [
+                "Fn::If": [
                   "Reboot",
                   "reboot",
                   { "Ref": "AWS::NoValue" }
@@ -508,116 +458,251 @@
               }
             ]
           },
-          "setup":
-          {
-            "files":
-            {
-              "/etc/cfn/cfn-hup.conf":
-              {
-                "content":
-                { "Fn::Join": ["", [
-                  "[main]\n",
-                  "stack=", { "Ref": "AWS::StackId" }, "\n",
-                  "region=", { "Ref": "AWS::Region" }, "\n",
-                  {
-                    "Fn::If":
+          "finalize": {
+            "commands": {
+              "10-signal-success": {
+                "command": {
+                  "Fn::Join": [
+                    "",
                     [
-                      "AssignInstanceRole",
-                      { "Fn::Join": [ "", [
-                        "role=",
-                        { "Ref": "InstanceRole" },
-                        "\n"
-                      ] ] },
-                      ""
+                      "/opt/aws/bin/cfn-signal -e 0",
+                      " --stack ",
+                      { "Ref": "AWS::StackName" },
+                      " --resource WatchmakerInstance",
+                      {
+                        "Fn::If": [
+                          "AssignInstanceRole",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --role ",
+                                { "Ref": "InstanceRole" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseCfnUrl",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --url ",
+                                { "Ref": "CfnEndpointUrl" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      " --region ",
+                      { "Ref": "AWS::Region" },
+                      "\n"
                     ]
-                  },
-                  {
-                    "Fn::If":
+                  ]
+                },
+                "ignoreErrors": "true"
+              }
+            }
+          },
+          "install-updates": {
+            "commands": {
+              "10-install-updates": {
+                "command": "yum -y update"
+              }
+            }
+          },
+          "make-app": {
+            "commands": {
+              "05-get-appscript": {
+                "command": {
+                  "Fn::Join": [
+                    "",
                     [
-                      "UseCfnUrl",
-                      { "Fn::Join": [ "", [
-                        "url=",
-                        { "Ref": "CfnEndpointUrl" },
-                        "\n"
-                      ] ] },
-                      ""
+                      "mkdir -p /etc/cfn/scripts &&",
+                      " aws s3 cp ",
+                      { "Ref": "AppScriptUrl" },
+                      " /etc/cfn/scripts/make-app",
+                      " --region ",
+                      { "Ref": "AWS::Region" },
+                      " &&",
+                      " chown root:root /etc/cfn/scripts/make-app &&",
+                      " chmod 700 /etc/cfn/scripts/make-app"
                     ]
-                  },
-                  "interval=1", "\n",
-                  "verbose=true", "\n"
-                ]]},
-                "mode"  : "000400",
-                "owner"   : "root",
-                "group"   : "root"
+                  ]
+                },
+                "env": {
+                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
+                  "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
+                }
               },
-              "/etc/cfn/hooks.d/cfn-auto-reloader.conf":
-              {
-                "content":
-                { "Fn::Join": ["", [
-                  "[cfn-auto-reloader-hook]\n",
-                  "triggers=post.update\n",
-                  "path=Resources.WatchmakerInstance.Metadata\n",
-                  "action=/opt/aws/bin/cfn-init -v -c update",
-                  " --stack ", { "Ref": "AWS::StackName" },
-                  " --resource WatchmakerInstance",
-                  {
-                    "Fn::If":
+              "10-make-app": {
+                "command": {
+                  "Fn::Join": [
+                    "",
                     [
-                      "AssignInstanceRole",
-                      { "Fn::Join": [ "", [
-                        " --role ",
-                        { "Ref": "InstanceRole" }
-                      ] ] },
-                      ""
+                      { "Ref": "AppScriptShell" },
+                      " /etc/cfn/scripts/make-app ",
+                      { "Ref": "AppScriptParams" }
                     ]
-                  },
-                  {
-                    "Fn::If":
+                  ]
+                },
+                "env": {
+                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
+                  "AWS_DEFAULT_REGION": { "Ref": "AWS::Region" },
+                  "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
+                }
+              }
+            }
+          },
+          "reboot": {
+            "commands": {
+              "10-reboot": {
+                "command": "shutdown -r +1 &"
+              }
+            }
+          },
+          "setup": {
+            "files": {
+              "/etc/cfn/cfn-hup.conf": {
+                "content": {
+                  "Fn::Join": [
+                    "",
                     [
-                      "UseCfnUrl",
-                      { "Fn::Join": [ "", [
-                        " --url ",
-                        { "Ref": "CfnEndpointUrl" }
-                      ] ] },
-                      ""
+                      "[main]\n",
+                      "stack=",
+                      { "Ref": "AWS::StackId" },
+                      "\n",
+                      "region=",
+                      { "Ref": "AWS::Region" },
+                      "\n",
+                      {
+                        "Fn::If": [
+                          "AssignInstanceRole",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "role=",
+                                { "Ref": "InstanceRole" },
+                                "\n"
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseCfnUrl",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                "url=",
+                                { "Ref": "CfnEndpointUrl" },
+                                "\n"
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      "interval=1",
+                      "\n",
+                      "verbose=true",
+                      "\n"
                     ]
-                  },
-                  " --region ", { "Ref": "AWS::Region" }, "\n",
-                  "runas=root\n"
-                ]]},
+                  ]
+                },
+                "group": "root",
                 "mode": "000400",
-                "owner": "root",
-                "group": "root"
+                "owner": "root"
               },
-              "/etc/cfn/scripts/watchmaker-install.sh":
-              {
-                "content":
-                { "Fn::Join": [ "", [
-                  "#!/bin/bash\n\n",
-
-                  "PYPI_URL=", { "Ref": "PypiIndexUrl" }, "\n",
-
-                  "pip install --index-url=\"$PYPI_URL\" wheel==0.29.0\n",
-
-                  "pip install",
-                  " --index-url=\"$PYPI_URL\"",
-                  " --upgrade pip setuptools boto3 watchmaker\n\n"
-                ]]},
+              "/etc/cfn/hooks.d/cfn-auto-reloader.conf": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "[cfn-auto-reloader-hook]\n",
+                      "triggers=post.update\n",
+                      "path=Resources.WatchmakerInstance.Metadata\n",
+                      "action=/opt/aws/bin/cfn-init -v -c update",
+                      " --stack ",
+                      { "Ref": "AWS::StackName" },
+                      " --resource WatchmakerInstance",
+                      {
+                        "Fn::If": [
+                          "AssignInstanceRole",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --role ",
+                                { "Ref": "InstanceRole" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseCfnUrl",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --url ",
+                                { "Ref": "CfnEndpointUrl" }
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      " --region ",
+                      { "Ref": "AWS::Region" },
+                      "\n",
+                      "runas=root\n"
+                    ]
+                  ]
+                },
+                "group": "root",
+                "mode": "000400",
+                "owner": "root"
+              },
+              "/etc/cfn/scripts/watchmaker-install.sh": {
+                "content": {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "#!/bin/bash\n\n",
+                      "PYPI_URL=",
+                      { "Ref": "PypiIndexUrl" },
+                      "\n",
+                      "pip install --index-url=\"$PYPI_URL\" wheel==0.29.0\n",
+                      "pip install",
+                      " --index-url=\"$PYPI_URL\"",
+                      " --upgrade pip setuptools boto3 watchmaker\n\n"
+                    ]
+                  ]
+                },
+                "group": "root",
                 "mode": "000700",
-                "owner": "root",
-                "group": "root"
+                "owner": "root"
               }
             },
-            "services":
-            {
-              "sysvinit":
-              {
-                "cfn-hup":
-                {
+            "services": {
+              "sysvinit": {
+                "cfn-hup": {
                   "enabled": "true",
                   "ensureRunning": "true",
-                  "files":
-                  [
+                  "files": [
                     "/etc/cfn/cfn-hup.conf",
                     "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
                   ]
@@ -625,571 +710,526 @@
               }
             }
           },
-          "install-updates":
-          {
-            "commands":
-            {
-              "10-install-updates":
-              {
-                "command": "yum -y update"
-              }
-            }
-          },
-          "watchmaker-install":
-          {
-            "commands":
-            {
-              "10-watchmaker-install":
-              {
+          "watchmaker-install": {
+            "commands": {
+              "10-watchmaker-install": {
                 "command": "bash -xe /etc/cfn/scripts/watchmaker-install.sh",
-                "env":
-                {
+                "env": {
+                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
                   "AWS_DEFAULT_REGION": { "Ref": "AWS::Region" },
-                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
                   "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
                 }
               }
             }
           },
-          "watchmaker-launch":
-          {
-            "commands":
-            {
-              "10-watchmaker-launch":
-              {
-                "command":
-                { "Fn::Join": [ "", [
-                  "watchmaker --log-level debug",
-                  " --log-dir /var/log/watchmaker",
-                  " --no-reboot",
-                  {
-                    "Fn::If":
+          "watchmaker-launch": {
+            "commands": {
+              "10-watchmaker-launch": {
+                "command": {
+                  "Fn::Join": [
+                    "",
                     [
-                      "UseWamConfig",
-                      { "Fn::Join": [ "", [
-                        " --config \"",
-                        { "Ref": "WatchmakerConfig" },
-                        "\""
-                      ]]},
-                      ""
+                      "watchmaker --log-level debug",
+                      " --log-dir /var/log/watchmaker",
+                      " --no-reboot",
+                      {
+                        "Fn::If": [
+                          "UseWamConfig",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --config \"",
+                                { "Ref": "WatchmakerConfig" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseEnvironment",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --env \"",
+                                { "Ref": "WatchmakerEnvironment" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseOuPath",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --ou-path \"",
+                                { "Ref": "WatchmakerOuPath" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseComputerName",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --computer-name \"",
+                                { "Ref": "WatchmakerComputerName" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminGroups",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-groups \"",
+                                { "Ref": "WatchmakerAdminGroups" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminUsers",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-users \"",
+                                { "Ref": "WatchmakerAdminUsers" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseS3Source",
+                          " --s3-source",
+                          ""
+                        ]
+                      }
                     ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseEnvironment",
-                      { "Fn::Join": [ "", [
-                        " --env \"",
-                        { "Ref": "WatchmakerEnvironment" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseOuPath",
-                      { "Fn::Join": [ "", [
-                        " --ou-path \"",
-                        { "Ref": "WatchmakerOuPath" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseComputerName",
-                      { "Fn::Join": [ "", [
-                        " --computer-name \"",
-                        { "Ref": "WatchmakerComputerName" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseAdminGroups",
-                      { "Fn::Join": [ "", [
-                        " --admin-groups \"",
-                        { "Ref": "WatchmakerAdminGroups" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseAdminUsers",
-                      { "Fn::Join": [ "", [
-                        " --admin-users \"",
-                        { "Ref": "WatchmakerAdminUsers" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseS3Source",
-                      " --s3-source",
-                      ""
-                    ]
-                  }
-                ]]}
-              }
-            }
-          },
-          "watchmaker-update":
-          {
-            "commands":
-            {
-              "10-watchmaker-update":
-              {
-                "command":
-                { "Fn::Join": [ "", [
-                  "watchmaker --log-level debug",
-                  " --log-dir /var/log/watchmaker",
-                  " --salt-states None",
-                  " --no-reboot",
-                  {
-                    "Fn::If":
-                    [
-                      "UseWamConfig",
-                      { "Fn::Join": [ "", [
-                        " --config \"",
-                        { "Ref": "WatchmakerConfig" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseEnvironment",
-                      { "Fn::Join": [ "", [
-                        " --env \"",
-                        { "Ref": "WatchmakerEnvironment" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseOuPath",
-                      { "Fn::Join": [ "", [
-                        " --oupath \"",
-                        { "Ref": "WatchmakerOuPath" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseComputerName",
-                      { "Fn::Join": [ "", [
-                        " --computer-name \"",
-                        { "Ref": "WatchmakerComputerName" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseAdminGroups",
-                      { "Fn::Join": [ "", [
-                        " --admin-groups \"",
-                        { "Ref": "WatchmakerAdminGroups" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseAdminUsers",
-                      { "Fn::Join": [ "", [
-                        " --admin-users \"",
-                        { "Ref": "WatchmakerAdminUsers" },
-                        "\""
-                      ]]},
-                      ""
-                    ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseS3Source",
-                      " --s3-source",
-                      ""
-                    ]
-                  }
-                ]]}
-              }
-            }
-          },
-          "make-app":
-          {
-            "commands":
-            {
-              "05-get-appscript":
-              {
-                "command":
-                { "Fn::Join": [ "", [
-                  "mkdir -p /etc/cfn/scripts &&",
-                  " aws s3 cp ",
-                  { "Ref": "AppScriptUrl" },
-                  " /etc/cfn/scripts/make-app",
-                  " --region ",
-                  { "Ref": "AWS::Region" }, " &&",
-                  " chown root:root /etc/cfn/scripts/make-app &&",
-                  " chmod 700 /etc/cfn/scripts/make-app"
-                ]]},
-                "env":
-                {
-                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
-                  "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
-                }
-              },
-              "10-make-app":
-              {
-                "command":
-                { "Fn::Join": [ "", [
-                  { "Ref": "AppScriptShell" },
-                  " /etc/cfn/scripts/make-app ",
-                  { "Ref": "AppScriptParams" }
-                ]]},
-                "env":
-                {
-                  "AWS_DEFAULT_REGION": { "Ref": "AWS::Region" },
-                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
-                  "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
+                  ]
                 }
               }
             }
           },
-          "finalize":
-          {
-            "commands":
-            {
-              "10-signal-success":
-              {
-                "command":
-                { "Fn::Join": [ "", [
-                  "/opt/aws/bin/cfn-signal -e 0",
-                  " --stack ", { "Ref": "AWS::StackName" },
-                  " --resource WatchmakerInstance",
-                  {
-                    "Fn::If":
+          "watchmaker-update": {
+            "commands": {
+              "10-watchmaker-update": {
+                "command": {
+                  "Fn::Join": [
+                    "",
                     [
-                      "AssignInstanceRole",
-                      { "Fn::Join": [ "", [
-                        " --role ",
-                        { "Ref": "InstanceRole" }
-                      ] ] },
-                      ""
+                      "watchmaker --log-level debug",
+                      " --log-dir /var/log/watchmaker",
+                      " --salt-states None",
+                      " --no-reboot",
+                      {
+                        "Fn::If": [
+                          "UseWamConfig",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --config \"",
+                                { "Ref": "WatchmakerConfig" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseEnvironment",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --env \"",
+                                { "Ref": "WatchmakerEnvironment" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseOuPath",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --oupath \"",
+                                { "Ref": "WatchmakerOuPath" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseComputerName",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --computer-name \"",
+                                { "Ref": "WatchmakerComputerName" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminGroups",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-groups \"",
+                                { "Ref": "WatchmakerAdminGroups" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseAdminUsers",
+                          {
+                            "Fn::Join": [
+                              "",
+                              [
+                                " --admin-users \"",
+                                { "Ref": "WatchmakerAdminUsers" },
+                                "\""
+                              ]
+                            ]
+                          },
+                          ""
+                        ]
+                      },
+                      {
+                        "Fn::If": [
+                          "UseS3Source",
+                          " --s3-source",
+                          ""
+                        ]
+                      }
                     ]
-                  },
-                  {
-                    "Fn::If":
-                    [
-                      "UseCfnUrl",
-                      { "Fn::Join": [ "", [
-                        " --url ",
-                        { "Ref": "CfnEndpointUrl" }
-                      ] ] },
-                      ""
-                    ]
-                  },
-                  " --region ", { "Ref": "AWS::Region"}, "\n"
-                ]]},
-                "ignoreErrors": "true"
-              }
-            }
-          },
-          "reboot":
-          {
-            "commands":
-            {
-              "10-reboot":
-              {
-                "command": "shutdown -r +1 &"
+                  ]
+                }
               }
             }
           }
-        }
-      },
-      "Properties":
-      {
-        "ImageId": { "Ref": "AmiId" },
-        "InstanceType": { "Ref": "InstanceType" },
-        "IamInstanceProfile":
-        {
-          "Fn::If":
-          [
-            "AssignInstanceRole",
-            { "Ref": "InstanceRole" },
-            { "Ref": "AWS::NoValue" }
-          ]
         },
-        "Tags":
-        [
+        "ToggleCfnInitUpdate": { "Ref": "ToggleCfnInitUpdate" }
+      },
+      "Properties": {
+        "BlockDeviceMappings": [
           {
-            "Key": "Name",
-            "Value":
-            { "Fn::Join": [ "", [
-              { "Ref": "AWS::StackName" }
-            ]]}
-          }
-        ],
-        "BlockDeviceMappings":
-        [
-          {
-            "DeviceName":
-            { "Fn::Join": [ "", [
-              "/dev/",
-              { "Fn::FindInMap":
+            "DeviceName": {
+              "Fn::Join": [
+                "",
                 [
-                  "Distro2RootDevice",
-                  { "Ref": "AmiDistro" },
-                  "DeviceName"
+                  "/dev/",
+                  {
+                    "Fn::FindInMap": [
+                      "Distro2RootDevice",
+                      { "Ref": "AmiDistro" },
+                      "DeviceName"
+                    ]
+                  }
                 ]
-              }
-            ]]},
-            "Ebs":
-            {
-              "VolumeType": "gp2",
-              "DeleteOnTermination": "true"
+              ]
+            },
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeType": "gp2"
             }
           },
           {
-            "Fn::If":
-            [
+            "Fn::If": [
               "CreateAppVolume",
               {
                 "DeviceName": { "Ref": "AppVolumeDevice" },
-                "Ebs":
-                {
+                "Ebs": {
+                  "DeleteOnTermination": "true",
                   "VolumeSize": { "Ref": "AppVolumeSize" },
-                  "VolumeType": { "Ref": "AppVolumeType" },
-                  "DeleteOnTermination": "true"
+                  "VolumeType": { "Ref": "AppVolumeType" }
                 }
               },
               { "Ref": "AWS::NoValue" }
             ]
           }
         ],
-        "KeyName":
-        {
-          "Ref": "KeyPairName"
+        "IamInstanceProfile": {
+          "Fn::If": [
+            "AssignInstanceRole",
+            { "Ref": "InstanceRole" },
+            { "Ref": "AWS::NoValue" }
+          ]
         },
-        "NetworkInterfaces":
-        [
+        "ImageId": { "Ref": "AmiId" },
+        "InstanceType": { "Ref": "InstanceType" },
+        "KeyName": { "Ref": "KeyPairName" },
+        "NetworkInterfaces": [
           {
-            "DeviceIndex": "0",
-            "AssociatePublicIpAddress":
-            {
-              "Fn::If":
-              [
+            "AssociatePublicIpAddress": {
+              "Fn::If": [
                 "AssignPublicIp",
                 "true",
                 "false"
               ]
             },
-            "PrivateIpAddress":
-            {
-              "Fn::If":
-              [
+            "DeviceIndex": "0",
+            "GroupSet": { "Ref": "SecurityGroupIds" },
+            "PrivateIpAddress": {
+              "Fn::If": [
                 "AssignStaticPrivateIp",
                 { "Ref": "PrivateIp" },
                 { "Ref": "AWS::NoValue" }
               ]
             },
-            "GroupSet": { "Ref": "SecurityGroupIds" },
             "SubnetId": { "Ref": "SubnetId" }
           }
         ],
-        "UserData":
-        {
-          "Fn::Base64":
-          { "Fn::Join": [ "", [
-            "Content-Type: multipart/mixed; boundary=\"===============3585321300151562773==\"\n",
-            "MIME-Version: 1.0\n",
-            "\n",
-
-            "--===============3585321300151562773==\n",
-            "Content-Type: text/cloud-config; charset=\"us-ascii\"\n",
-            "MIME-Version: 1.0\n",
-            "Content-Transfer-Encoding: 7bit\n",
-            "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
-            "\n",
-
-            "#cloud-config\n",
-            {
-              "Fn::If":
-              [
-                "CreateAppVolume",
-                { "Fn::Join": [ "", [
-                  "bootcmd:\n",
-                  "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
-                  { "Ref": "AppVolumeDevice" },
-                  "\n",
-                  "mounts:\n",
-                  "- [ ",
-                  { "Ref": "AppVolumeDevice" }, ", ",
-                  { "Ref": "AppVolumeMountPath" },
-                  " ]\n"
-                ]]},
-                { "Ref": "AWS::NoValue" }
+        "Tags": [
+          {
+            "Key": "Name",
+            "Value": {
+              "Fn::Join": [
+                "",
+                [
+                  { "Ref": "AWS::StackName" }
+                ]
               ]
-            },
-
-            "\n",
-
-            "--===============3585321300151562773==\n",
-            "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
-            "MIME-Version: 1.0\n",
-            "Content-Transfer-Encoding: 7bit\n",
-            "Content-Disposition: attachment; filename=\"script.sh\"\n",
-            "\n",
-
-            "#!/bin/bash -xe\n\n",
-
-            "# Export cert bundle ENVs\n",
-            "export AWS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
-            "export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n\n",
-
-            "# Get pip\n",
-            "curl --silent --show-error --retry 5 -L ",
-            { "Ref": "CfnGetPipUrl" },
-            " | python - --index-url=", { "Ref": "PypiIndexUrl" }, "\n\n",
-
-            "# Add pip to path\n",
-            "hash pip 2> /dev/null || ",
-            "PATH=\"${PATH}:/usr/local/bin\"", "\n\n",
-
-            "# Upgrade pip and setuptools\n",
-            "PYPI_URL=", { "Ref": "PypiIndexUrl" }, "\n",
-            "pip install",
-            " --index-url=\"$PYPI_URL\"",
-            " --upgrade pip setuptools\n\n",
-
-            "# Fix python urllib3 warnings\n",
-            "yum -y install gcc python-devel libffi-devel openssl-devel\n",
-            "pip install",
-            " --index-url=\"$PYPI_URL\"",
-            " --upgrade pyopenssl ndg-httpsclient pyasn1\n\n",
-
-            "# Get cfn utils\n",
-            "pip install",
-            " --index-url=\"$PYPI_URL\"",
-            " --upgrade ",
-            { "Ref": "CfnBootstrapUtilsUrl" },
-            "\n\n",
-
-            "# Remove gcc now that it is no longer needed\n",
-            "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
-
-            "# Fixup cfn utils\n",
-            "INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat ",
-            "2> /dev/null || echo /usr/init/redhat)\n",
-            "chmod 775 ${INITDIR}/cfn-hup\n",
-            "ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
-            "chkconfig --add cfn-hup\n",
-            "chkconfig cfn-hup on\n",
-            "mkdir -p /opt/aws/bin\n",
-            "BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin ",
-            "2> /dev/null || echo /usr/bin)\n",
-            "for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup ",
-            "cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
-            "do\n",
-            "  ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
-            "  echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
-            "done\n\n",
-
-            "# Add cfn-signal to path\n",
-            "hash cfn-signal 2> /dev/null || ",
-            "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
-            "\n\n",
-
-            "# Execute cfn-init\n",
-            "/opt/aws/bin/cfn-init -v -c launch",
-            " --stack ", { "Ref": "AWS::StackName" },
-            " --resource WatchmakerInstance",
-            {
-              "Fn::If":
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [
+              "",
               [
-                "AssignInstanceRole",
-                { "Fn::Join": [ "", [
-                  " --role ", { "Ref": "InstanceRole" }
-                ] ] },
-                ""
+                "Content-Type: multipart/mixed; boundary=\"===============3585321300151562773==\"\n",
+                "MIME-Version: 1.0\n",
+                "\n",
+                "--===============3585321300151562773==\n",
+                "Content-Type: text/cloud-config; charset=\"us-ascii\"\n",
+                "MIME-Version: 1.0\n",
+                "Content-Transfer-Encoding: 7bit\n",
+                "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
+                "\n",
+                "#cloud-config\n",
+                {
+                  "Fn::If": [
+                    "CreateAppVolume",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          "bootcmd:\n",
+                          "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
+                          { "Ref": "AppVolumeDevice" },
+                          "\n",
+                          "mounts:\n",
+                          "- [ ",
+                          { "Ref": "AppVolumeDevice" },
+                          ", ",
+                          { "Ref": "AppVolumeMountPath" },
+                          " ]\n"
+                        ]
+                      ]
+                    },
+                    { "Ref": "AWS::NoValue" }
+                  ]
+                },
+                "\n",
+                "--===============3585321300151562773==\n",
+                "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
+                "MIME-Version: 1.0\n",
+                "Content-Transfer-Encoding: 7bit\n",
+                "Content-Disposition: attachment; filename=\"script.sh\"\n",
+                "\n",
+                "#!/bin/bash -xe\n\n",
+                "# Export cert bundle ENVs\n",
+                "export AWS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
+                "export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n\n",
+                "# Get pip\n",
+                "curl --silent --show-error --retry 5 -L ",
+                { "Ref": "CfnGetPipUrl" },
+                " | python - --index-url=",
+                { "Ref": "PypiIndexUrl" },
+                "\n\n",
+                "# Add pip to path\n",
+                "hash pip 2> /dev/null || ",
+                "PATH=\"${PATH}:/usr/local/bin\"",
+                "\n\n",
+                "# Upgrade pip and setuptools\n",
+                "PYPI_URL=",
+                { "Ref": "PypiIndexUrl" },
+                "\n",
+                "pip install",
+                " --index-url=\"$PYPI_URL\"",
+                " --upgrade pip setuptools\n\n",
+                "# Fix python urllib3 warnings\n",
+                "yum -y install gcc python-devel libffi-devel openssl-devel\n",
+                "pip install",
+                " --index-url=\"$PYPI_URL\"",
+                " --upgrade pyopenssl ndg-httpsclient pyasn1\n\n",
+                "# Get cfn utils\n",
+                "pip install",
+                " --index-url=\"$PYPI_URL\"",
+                " --upgrade ",
+                { "Ref": "CfnBootstrapUtilsUrl" },
+                "\n\n",
+                "# Remove gcc now that it is no longer needed\n",
+                "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
+                "# Fixup cfn utils\n",
+                "INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat ",
+                "2> /dev/null || echo /usr/init/redhat)\n",
+                "chmod 775 ${INITDIR}/cfn-hup\n",
+                "ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
+                "chkconfig --add cfn-hup\n",
+                "chkconfig cfn-hup on\n",
+                "mkdir -p /opt/aws/bin\n",
+                "BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin ",
+                "2> /dev/null || echo /usr/bin)\n",
+                "for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup ",
+                "cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
+                "do\n",
+                "  ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
+                "  echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
+                "done\n\n",
+                "# Add cfn-signal to path\n",
+                "hash cfn-signal 2> /dev/null || ",
+                "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
+                "\n\n",
+                "# Execute cfn-init\n",
+                "/opt/aws/bin/cfn-init -v -c launch",
+                " --stack ",
+                { "Ref": "AWS::StackName" },
+                " --resource WatchmakerInstance",
+                {
+                  "Fn::If": [
+                    "AssignInstanceRole",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --role ",
+                          { "Ref": "InstanceRole" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                {
+                  "Fn::If": [
+                    "UseCfnUrl",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --url ",
+                          { "Ref": "CfnEndpointUrl" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                " --region ",
+                { "Ref": "AWS::Region" },
+                " ||",
+                " ( echo 'ERROR: cfn-init failed! Aborting!';",
+                " /opt/aws/bin/cfn-signal -e 1",
+                "  --stack ",
+                { "Ref": "AWS::StackName" },
+                "  --resource WatchmakerInstance",
+                {
+                  "Fn::If": [
+                    "AssignInstanceRole",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --role ",
+                          { "Ref": "InstanceRole" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                {
+                  "Fn::If": [
+                    "UseCfnUrl",
+                    {
+                      "Fn::Join": [
+                        "",
+                        [
+                          " --url ",
+                          { "Ref": "CfnEndpointUrl" }
+                        ]
+                      ]
+                    },
+                    ""
+                  ]
+                },
+                "  --region ",
+                { "Ref": "AWS::Region" },
+                ";",
+                " exit 1",
+                " )\n\n",
+                "--===============3585321300151562773==--"
               ]
-            },
-            {
-              "Fn::If":
-              [
-                "UseCfnUrl",
-                { "Fn::Join": [ "", [
-                  " --url ", { "Ref": "CfnEndpointUrl" }
-                ] ] },
-                ""
-              ]
-            },
-            " --region ", { "Ref": "AWS::Region" }, " ||",
-            " ( echo 'ERROR: cfn-init failed! Aborting!';",
-            " /opt/aws/bin/cfn-signal -e 1",
-            "  --stack ", { "Ref": "AWS::StackName" },
-            "  --resource WatchmakerInstance",
-            {
-              "Fn::If":
-              [
-                "AssignInstanceRole",
-                { "Fn::Join": [ "", [
-                  " --role ", { "Ref": "InstanceRole" }
-                ] ] },
-                ""
-              ]
-            },
-            {
-              "Fn::If":
-              [
-                "UseCfnUrl",
-                { "Fn::Join": [ "", [
-                  " --url ", { "Ref": "CfnEndpointUrl" }
-                ] ] },
-                ""
-              ]
-            },
-            "  --region ", { "Ref": "AWS::Region"}, ";",
-            " exit 1",
-            " )\n\n",
-            "--===============3585321300151562773==--"
-          ] ] }
+            ]
+          }
         }
-      }
-    }
-  },
-  "Outputs":
-  {
-    "WatchmakerInstanceId":
-    {
-      "Value": { "Ref": "WatchmakerInstance" },
-      "Description": "Instance ID"
+      },
+      "Type": "AWS::EC2::Instance"
     }
   }
 }

--- a/docs/files/templates/lx-instance/watchmaker-lx-instance.template
+++ b/docs/files/templates/lx-instance/watchmaker-lx-instance.template
@@ -17,9 +17,7 @@
       ]
     },
     "CreateAppVolume": {
-      "Fn::Not": [
-        { "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "" ] }
-      ]
+      "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "true" ] 
     },
     "ExecuteAppScript": {
       "Fn::Not": [
@@ -29,34 +27,6 @@
     "InstallUpdates": {
       "Fn::Not": [
         { "Fn::Equals": [ { "Ref": "NoUpdates" }, "true" ] }
-      ]
-    },
-    "NotGenFive": {
-      "Fn::Not": [
-        {
-          "Fn::Or": [
-            {
-              "Fn::Equals": [
-                { "Fn::Select": [
-                    "0",
-                    { "Fn::Split": [ ".", { "Ref": "InstanceType" } ] }
-                  ]
-                },
-                "c5"
-              ]
-            },
-            {
-              "Fn::Equals": [
-                { "Fn::Select": [
-                    "0",
-                    { "Fn::Split": [ ".", { "Ref": "InstanceType" } ] }
-                  ]
-                },
-                "m5"
-              ]
-            }
-          ]
-        }
       ]
     },
     "Reboot": {
@@ -117,6 +87,60 @@
       "RedHat": {
         "DeviceName": "sda1"
       }
+    },
+    "InstanceTypeCapabilities": {
+        "t2.micro": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "t2.small": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "t2.medium": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "t2.large": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "t2.xlarge": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "m5.large": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/nvme1n1"
+        },
+        "m5.xlarge": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/nvme1n1"
+        },
+        "c5.large": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/nvme1n1"
+        },
+        "c5.xlarge": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/nvme1n1"
+        },
+        "m4.large": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "m4.xlarge": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "c4.large": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        },
+        "c4.xlarge": {
+          "ExternDeviceName": "/dev/xvdf",
+          "InternDeviceName": "/dev/xvdf"
+        }
     }
   },
   "Metadata": {
@@ -245,15 +269,11 @@
     },
     "AppVolumeDevice": {
       "AllowedValues": [
-        "",
-        "/dev/xvdf",
-        "/dev/xvdg",
-        "/dev/xvdh",
-        "/dev/xvdi",
-        "/dev/xvdj"
+        "true",
+        "false"
       ],
-      "Default": "",
-      "Description": "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume",
+      "Default": "false",
+      "Description": "Whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume",
       "Type": "String"
     },
     "AppVolumeMountPath": {
@@ -1024,7 +1044,13 @@
             "Fn::If": [
               "CreateAppVolume",
               {
-                "DeviceName": { "Ref": "AppVolumeDevice" },
+                "DeviceName": {
+                  "Fn::FindInMap": [
+                    "InstanceTypeCapabilities",
+                    { "Ref": "InstanceType" },
+                    "ExternDeviceName"
+                  ]
+                },
                 "Ebs": {
                   "DeleteOnTermination": "true",
                   "VolumeSize": { "Ref": "AppVolumeSize" },
@@ -1103,11 +1129,23 @@
                         [
                           "bootcmd:\n",
                           "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
-                          { "Ref": "AppVolumeDevice" },
+                          {
+                            "Fn::FindInMap": [
+                              "InstanceTypeCapabilities",
+                              { "Ref": "InstanceType" },
+                              "InternDeviceName"
+                            ]
+                          },
                           "\n",
                           "mounts:\n",
                           "- [ ",
-                          { "Ref": "AppVolumeDevice" },
+                          {
+                            "Fn::FindInMap": [
+                              "InstanceTypeCapabilities",
+                              { "Ref": "InstanceType" },
+                              "InternDeviceName"
+                            ]
+                          },
                           ", ",
                           { "Ref": "AppVolumeMountPath" },
                           " ]\n"

--- a/docs/files/templates/lx-instance/watchmaker-lx-instance.template
+++ b/docs/files/templates/lx-instance/watchmaker-lx-instance.template
@@ -31,6 +31,34 @@
         { "Fn::Equals": [ { "Ref": "NoUpdates" }, "true" ] }
       ]
     },
+    "NotGenFive": {
+      "Fn::Not": [
+        {
+          "Fn::Or": [
+            {
+              "Fn::Equals": [
+                { "Fn::Select": [
+                    "0",
+                    { "Fn::Split": [ ".", { "Ref": "InstanceType" } ] }
+                  ]
+                },
+                "c5"
+              ]
+            },
+            {
+              "Fn::Equals": [
+                { "Fn::Select": [
+                    "0",
+                    { "Fn::Split": [ ".", { "Ref": "InstanceType" } ] }
+                  ]
+                },
+                "m5"
+              ]
+            }
+          ]
+        }
+      ]
+    },
     "Reboot": {
       "Fn::Not": [
         { "Fn::Equals": [ { "Ref": "NoReboot" }, "true" ] }
@@ -283,10 +311,15 @@
         "t2.small",
         "t2.medium",
         "t2.large",
-        "c4.large",
-        "c4.xlarge",
+        "t2.xlarge",
+        "m5.large",
+        "m5.xlarge",
+        "c5.large",
+        "c5.xlarge",
         "m4.large",
-        "m4.xlarge"
+        "m4.xlarge",
+        "c4.large",
+        "c4.xlarge"
       ],
       "Default": "t2.micro",
       "Description": "Amazon EC2 instance type",

--- a/docs/files/templates/lx-instance/watchmaker-lx-instance.template
+++ b/docs/files/templates/lx-instance/watchmaker-lx-instance.template
@@ -1,1195 +1,1195 @@
 {
-    "AWSTemplateFormatVersion" : "2010-09-09",
-    "Description" : "This template deploys a Linux instance using Watchmaker, which applies the DISA STIG.",
-    "Parameters" :
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "This template deploys a Linux instance using Watchmaker, which applies the DISA STIG.",
+  "Parameters":
+  {
+    "AmiId":
     {
-        "AmiId" :
-        {
-            "Description" : "ID of the AMI to launch",
-            "Type" : "String",
-            "AllowedPattern" : "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$"
-        },
-        "AmiDistro" :
-        {
-            "Description" : "Linux distro of the AMI",
-            "Type" : "String",
-            "AllowedValues" :
-            [
-                "AmazonLinux",
-                "CentOS",
-                "RedHat"
-            ]
-        },
-        "AppScriptParams" :
-        {
-            "Description" : "Parameter string to pass to the application script. Ignored if \"AppScriptUrl\" is blank",
-            "Type" : "String"
-        },
-        "AppScriptShell" :
-        {
-            "Description" : "Shell with which to execute the application script. Ignored if \"AppScriptUrl\" is blank",
-            "Type" : "String",
-            "Default" : "bash",
-            "AllowedValues" :
-            [
-                "bash",
-                "python"
-            ]
-        },
-        "AppScriptUrl" :
-        {
-            "Description" : "(Optional) S3 URL to the application script in an S3 bucket (s3://). Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
-            "Type" : "String",
-            "Default" : "",
-            "AllowedPattern" : "^$|^s3://(.*)$",
-            "ConstraintDescription" : "Must use an S3 URL (starts with \"s3://\")"
-        },
-        "AppVolumeDevice" :
-        {
-            "Description" : "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume",
-            "Type" : "String",
-            "Default" : "",
-            "AllowedValues" :
-            [
-                "",
-                "/dev/xvdf",
-                "/dev/xvdg",
-                "/dev/xvdh",
-                "/dev/xvdi",
-                "/dev/xvdj"
-            ]
-        },
-        "AppVolumeMountPath" :
-        {
-            "Description" : "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
-            "Type" : "String",
-            "Default" : "/opt/data",
-            "AllowedPattern" : "/.*"
-        },
-        "AppVolumeType" :
-        {
-            "Description" : "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
-            "Type" : "String",
-            "Default" : "gp2",
-            "AllowedValues" :
-            [
-                "gp2",
-                "io1",
-                "sc1",
-                "st1",
-                "standard"
-            ]
-        },
-        "AppVolumeSize" :
-        {
-            "Description" : "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
-            "Type" : "Number",
-            "Default" : "1",
-            "MinValue": "1",
-            "MaxValue": "16384",
-            "ConstraintDescription" : "Must be between 1GB and 16384GB."
-        },
-        "KeyPairName" :
-        {
-            "Description" : "Public/private key pairs allow you to securely connect to your instance after it launches",
-            "Type" : "AWS::EC2::KeyPair::KeyName"
-        },
-        "InstanceType" :
-        {
-            "Description" : "Amazon EC2 instance type",
-            "Type" : "String",
-            "Default" : "t2.micro",
-            "AllowedValues" :
-            [
-                "t2.micro",
-                "t2.small",
-                "t2.medium",
-                "t2.large",
-                "c4.large",
-                "c4.xlarge",
-                "m4.large",
-                "m4.xlarge"
-            ]
-        },
-        "InstanceRole" :
-        {
-            "Description" : "(Optional) IAM instance role to apply to the instance",
-            "Type" : "String",
-            "Default" : ""
-        },
-        "PrivateIp" :
-        {
-            "Description" : "(Optional) Set a static, primary private IP. Leave blank to auto-select a free IP",
-            "Type" : "String",
-            "Default" : ""
-        },
-        "NoPublicIp" :
-        {
-            "Description" : "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
-            "Type" : "String",
-            "Default" : "true",
-            "AllowedValues" :
-            [
-                "false",
-                "true"
-            ]
-        },
-        "NoReboot" :
-        {
-            "Description" : "Controls whether to reboot the instance as the last step of cfn-init execution",
-            "Type" : "String",
-            "Default" : "false",
-            "AllowedValues" :
-            [
-                "false",
-                "true"
-            ]
-        },
-        "NoUpdates" :
-        {
-            "Description" : "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
-            "Type" : "String",
-            "Default" : "false",
-            "AllowedValues" :
-            [
-                "false",
-                "true"
-            ]
-        },
-        "SecurityGroupIds" :
-        {
-            "Description" : "List of security groups to apply to the instance",
-            "Type" : "List<AWS::EC2::SecurityGroup::Id>"
-        },
-        "SubnetId" :
-        {
-          "Type" : "AWS::EC2::Subnet::Id",
-          "Description" : "ID of the subnet to assign to the instance"
-        },
-        "PypiIndexUrl" :
-        {
-            "Description" : "URL to the PyPi Index",
-            "Type" : "String",
-            "Default" : "https://pypi.org/simple",
-            "AllowedPattern" : "^http[s]?://.*$"
-        },
-        "WatchmakerConfig" :
-        {
-            "Description" : "(Optional) URL to a Watchmaker config file",
-            "Type" : "String",
-            "Default" : "",
-            "AllowedPattern" : "^$|^http[s]?://.*$"
-        },
-        "WatchmakerEnvironment" :
-        {
-            "Description" : "Environment in which the instance is being deployed",
-            "Type" : "String",
-            "Default" : "",
-            "AllowedValues" :
-            [
-                "",
-                "dev",
-                "test",
-                "prod"
-            ]
-        },
-        "WatchmakerOuPath" :
-        {
-            "Description" : "(Optional) DN of the OU to place the instance when joining a domain. If blank and \"WatchmakerEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"WatchmakerEnvironment\" is \"false\"",
-            "Type" : "String",
-            "Default" : "",
-            "AllowedPattern" : "^$|^(OU=.+,)+(DC=.+)+$"
-        },
-        "WatchmakerComputerName" :
-        {
-            "Description" : "(Optional) Sets the hostname/computername within the OS",
-            "Type" : "String",
-            "Default" : ""
-        },
-        "WatchmakerAdminGroups" :
-        {
-            "Description" : "(Optional) Colon-separated list of domain groups that should have admin permissions on the EC2 instance",
-            "Type" : "String",
-            "Default" : ""
-        },
-        "WatchmakerAdminUsers" :
-        {
-            "Description" : "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
-            "Type" : "String",
-            "Default" : ""
-        },
-        "WatchmakerS3Source" :
-        {
-            "Description" : "Flag that tells watchmaker to use its instance role to retrieve watchmaker content from S3",
-            "Type" : "String",
-            "Default" : "false",
-            "AllowedValues" :
-            [
-                "false",
-                "true"
-            ]
-        },
-        "CfnEndpointUrl" :
-        {
-            "Description" : "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
-            "Type" : "String",
-            "Default" : "https://cloudformation.us-east-1.amazonaws.com",
-            "AllowedPattern" : "^$|^http[s]?://.*$"
-        },
-        "CfnGetPipUrl" :
-        {
-            "Description" : "URL to get-pip.py",
-            "Type" : "String",
-            "Default" : "https://bootstrap.pypa.io/get-pip.py",
-            "AllowedPattern" : "^http[s]?://.*\\.py$"
-        },
-        "CfnBootstrapUtilsUrl" :
-        {
-            "Description" : "URL to aws-cfn-bootstrap-latest.tar.gz",
-            "Type" : "String",
-            "Default" : "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
-            "AllowedPattern" : "^http[s]?://.*\\.tar\\.gz$"
-        },
-        "ToggleCfnInitUpdate" :
-        {
-            "Description" : "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
-            "Type" : "String",
-            "Default" : "A",
-            "AllowedValues" :
-            [
-                "A",
-                "B"
-            ]
-        }
+      "Description": "ID of the AMI to launch",
+      "Type": "String",
+      "AllowedPattern": "^ami-[0-9a-z]{8}$|^ami-[0-9a-z]{17}$"
     },
-    "Conditions" :
+    "AmiDistro":
     {
-        "ExecuteAppScript" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AppScriptUrl" }, "" ] } ]
-        },
-        "CreateAppVolume" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "AppVolumeDevice" }, "" ] } ]
-        },
-        "UseWamConfig" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerConfig" }, "" ] } ]
-        },
-        "UseOuPath" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerOuPath" }, "" ] } ]
-        },
-        "UseComputerName" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerComputerName" }, "" ] } ]
-        },
-        "UseAdminGroups" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerAdminGroups" }, "" ] } ]
-        },
-        "UseAdminUsers" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerAdminUsers" }, "" ] } ]
-        },
-        "UseS3Source" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerS3Source" }, "false" ] } ]
-        },
-        "UseEnvironment" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "WatchmakerEnvironment" }, "" ] } ]
-        },
-        "UseCfnUrl" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "CfnEndpointUrl" }, "" ] } ]
-        },
-        "InstallUpdates" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoUpdates" }, "true" ] } ]
-        },
-        "Reboot" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoReboot" }, "true" ] } ]
-        },
-        "AssignInstanceRole" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "InstanceRole" }, "" ] } ]
-        },
-        "AssignStaticPrivateIp" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "PrivateIp" }, "" ] } ]
-        },
-        "AssignPublicIp" :
-        {
-            "Fn::Not" : [ { "Fn::Equals" : [ { "Ref" : "NoPublicIp" }, "true" ] } ]
-        }
+      "Description": "Linux distro of the AMI",
+      "Type": "String",
+      "AllowedValues":
+      [
+        "AmazonLinux",
+        "CentOS",
+        "RedHat"
+      ]
     },
-    "Mappings" :
+    "AppScriptParams":
     {
-        "Distro2RootDevice" :
-        {
-            "AmazonLinux" : { "DeviceName" : "xvda" },
-            "RedHat" : { "DeviceName" : "sda1" },
-            "CentOS" : { "DeviceName" : "sda1" }
-        }
+      "Description": "Parameter string to pass to the application script. Ignored if \"AppScriptUrl\" is blank",
+      "Type": "String"
     },
-    "Metadata" :
+    "AppScriptShell":
     {
-        "AWS::CloudFormation::Interface" :
-        {
-            "ParameterGroups" :
-            [
-                {
-                    "Label" :
-                    {
-                      "default" : "EC2 Instance Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "AmiId",
-                        "AmiDistro",
-                        "InstanceType",
-                        "InstanceRole",
-                        "KeyPairName",
-                        "NoPublicIp",
-                        "NoReboot",
-                        "NoUpdates",
-                        "SecurityGroupIds"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                      "default" : "EC2 Watchmaker Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "PypiIndexUrl",
-                        "WatchmakerConfig",
-                        "WatchmakerEnvironment",
-                        "WatchmakerOuPath",
-                        "WatchmakerComputerName",
-                        "WatchmakerAdminGroups",
-                        "WatchmakerAdminUsers",
-                        "WatchmakerS3Source"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                        "default" : "EC2 Application Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "AppScriptUrl",
-                        "AppScriptParams",
-                        "AppScriptShell"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                        "default" : "EC2 Application EBS Volume"
-                    },
-                    "Parameters" :
-                    [
-                        "AppVolumeDevice",
-                        "AppVolumeMountPath",
-                        "AppVolumeSize",
-                        "AppVolumeType"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                        "default" : "Network Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "PrivateIp",
-                        "SubnetId"
-                    ]
-                },
-                {
-                    "Label" :
-                    {
-                        "default" : "CloudFormation Configuration"
-                    },
-                    "Parameters" :
-                    [
-                        "CfnEndpointUrl",
-                        "CfnGetPipUrl",
-                        "CfnBootstrapUtilsUrl",
-                        "ToggleCfnInitUpdate"
-                    ]
-                }
-            ],
-            "ParameterLabels" :
-            {
-                "ToggleCfnInitUpdate" :
-                {
-                    "default" : "Force Cfn Init Update"
-                }
-            }
-        }
+      "Description": "Shell with which to execute the application script. Ignored if \"AppScriptUrl\" is blank",
+      "Type": "String",
+      "Default": "bash",
+      "AllowedValues":
+      [
+        "bash",
+        "python"
+      ]
     },
-    "Resources" :
+    "AppScriptUrl":
     {
-        "WatchmakerInstance" :
-        {
-            "Type" : "AWS::EC2::Instance",
-            "CreationPolicy" :
-            {
-                "ResourceSignal" :
-                {
-                    "Count" : "1",
-                    "Timeout" : "PT30M"
-                }
-            },
-            "Metadata" : {
-                "ToggleCfnInitUpdate" : { "Ref" : "ToggleCfnInitUpdate" },
-                "AWS::CloudFormation::Init" :
-                {
-                    "configSets" :
-                    {
-                        "launch" :
-                        [
-                            "setup",
-                            "watchmaker-install",
-                            "watchmaker-launch",
-                            {
-                                "Fn::If" :
-                                [
-                                    "ExecuteAppScript",
-                                    "make-app",
-                                    { "Ref" : "AWS::NoValue" }
-                                ]
-                            },
-                            "finalize",
-                            {
-                                "Fn::If" :
-                                [
-                                    "Reboot",
-                                    "reboot",
-                                    { "Ref" : "AWS::NoValue" }
-                                ]
-                            }
-                        ],
-                        "update" :
-                        [
-                            "setup",
-                            {
-                                "Fn::If" :
-                                [
-                                    "InstallUpdates",
-                                    "install-updates",
-                                    { "Ref" : "AWS::NoValue" }
-                                ]
-                            },
-                            "watchmaker-install",
-                            "watchmaker-update",
-                            {
-                                "Fn::If" :
-                                [
-                                    "ExecuteAppScript",
-                                    "make-app",
-                                    { "Ref" : "AWS::NoValue" }
-                                ]
-                            },
-                            "finalize",
-                            {
-                                "Fn::If" :
-                                [
-                                    "Reboot",
-                                    "reboot",
-                                    { "Ref" : "AWS::NoValue" }
-                                ]
-                            }
-                        ]
-                    },
-                    "setup" :
-                    {
-                        "files" :
-                        {
-                            "/etc/cfn/cfn-hup.conf" :
-                            {
-                                "content" :
-                                { "Fn::Join" : ["", [
-                                    "[main]\n",
-                                    "stack=", { "Ref" : "AWS::StackId" }, "\n",
-                                    "region=", { "Ref" : "AWS::Region" }, "\n",
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "AssignInstanceRole",
-                                            { "Fn::Join" : [ "", [
-                                                "role=",
-                                                { "Ref" : "InstanceRole" },
-                                                "\n"
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseCfnUrl",
-                                            { "Fn::Join" : [ "", [
-                                                "url=",
-                                                { "Ref" : "CfnEndpointUrl" },
-                                                "\n"
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    "interval=1", "\n",
-                                    "verbose=true", "\n"
-                                ]]},
-                                "mode"    : "000400",
-                                "owner"   : "root",
-                                "group"   : "root"
-                            },
-                            "/etc/cfn/hooks.d/cfn-auto-reloader.conf" :
-                            {
-                                "content" :
-                                { "Fn::Join" : ["", [
-                                    "[cfn-auto-reloader-hook]\n",
-                                    "triggers=post.update\n",
-                                    "path=Resources.WatchmakerInstance.Metadata\n",
-                                    "action=/opt/aws/bin/cfn-init -v -c update",
-                                    " --stack ", { "Ref" : "AWS::StackName" },
-                                    " --resource WatchmakerInstance",
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "AssignInstanceRole",
-                                            { "Fn::Join" : [ "", [
-                                                " --role ",
-                                                { "Ref" : "InstanceRole" }
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseCfnUrl",
-                                            { "Fn::Join" : [ "", [
-                                                " --url ",
-                                                { "Ref" : "CfnEndpointUrl" }
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    " --region ", { "Ref" : "AWS::Region" }, "\n",
-                                    "runas=root\n"
-                                ]]},
-                                "mode" : "000400",
-                                "owner" : "root",
-                                "group" : "root"
-                            },
-                            "/etc/cfn/scripts/watchmaker-install.sh" :
-                            {
-                                "content" :
-                                { "Fn::Join" : [ "", [
-                                  "#!/bin/bash\n\n",
-
-                                  "PYPI_URL=", { "Ref" : "PypiIndexUrl" }, "\n",
-
-                                  "pip install --index-url=\"$PYPI_URL\" wheel==0.29.0\n",
-
-                                  "pip install",
-                                  " --index-url=\"$PYPI_URL\"",
-                                  " --upgrade pip setuptools boto3 watchmaker\n\n"
-                                ]]},
-                                "mode" : "000700",
-                                "owner" : "root",
-                                "group" : "root"
-                            }
-                        },
-                        "services" :
-                        {
-                            "sysvinit" :
-                            {
-                                "cfn-hup" :
-                                {
-                                    "enabled" : "true",
-                                    "ensureRunning" : "true",
-                                    "files" :
-                                    [
-                                        "/etc/cfn/cfn-hup.conf",
-                                        "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
-                                    ]
-                                }
-                            }
-                        }
-                    },
-                    "install-updates" :
-                    {
-                        "commands" :
-                        {
-                            "10-install-updates" :
-                            {
-                                "command" : "yum -y update"
-                            }
-                        }
-                    },
-                    "watchmaker-install" :
-                    {
-                        "commands" :
-                        {
-                            "10-watchmaker-install" :
-                            {
-                                "command" : "bash -xe /etc/cfn/scripts/watchmaker-install.sh",
-                                "env" :
-                                {
-                                  "AWS_DEFAULT_REGION" : { "Ref" : "AWS::Region" },
-                                  "AWS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt",
-                                  "REQUESTS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt"
-                                }
-                            }
-                        }
-                    },
-                    "watchmaker-launch" :
-                    {
-                        "commands" :
-                        {
-                            "10-watchmaker-launch" :
-                            {
-                                "command" :
-                                { "Fn::Join" : [ "", [
-                                    "watchmaker --log-level debug",
-                                    " --log-dir /var/log/watchmaker",
-                                    " --no-reboot",
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseWamConfig",
-                                            { "Fn::Join" : [ "", [
-                                                " --config \"",
-                                                { "Ref" : "WatchmakerConfig" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseEnvironment",
-                                            { "Fn::Join" : [ "", [
-                                                " --env \"",
-                                                { "Ref" : "WatchmakerEnvironment" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseOuPath",
-                                            { "Fn::Join" : [ "", [
-                                                " --ou-path \"",
-                                                { "Ref" : "WatchmakerOuPath" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseComputerName",
-                                            { "Fn::Join" : [ "", [
-                                                " --computer-name \"",
-                                                { "Ref" : "WatchmakerComputerName" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseAdminGroups",
-                                            { "Fn::Join" : [ "", [
-                                                " --admin-groups \"",
-                                                { "Ref" : "WatchmakerAdminGroups" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseAdminUsers",
-                                            { "Fn::Join" : [ "", [
-                                                " --admin-users \"",
-                                                { "Ref" : "WatchmakerAdminUsers" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseS3Source",
-                                            " --s3-source",
-                                            ""
-                                        ]
-                                    }
-                                ]]}
-                            }
-                        }
-                    },
-                    "watchmaker-update" :
-                    {
-                        "commands" :
-                        {
-                            "10-watchmaker-update" :
-                            {
-                                "command" :
-                                { "Fn::Join" : [ "", [
-                                    "watchmaker --log-level debug",
-                                    " --log-dir /var/log/watchmaker",
-                                    " --salt-states None",
-                                    " --no-reboot",
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseWamConfig",
-                                            { "Fn::Join" : [ "", [
-                                                " --config \"",
-                                                { "Ref" : "WatchmakerConfig" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseEnvironment",
-                                            { "Fn::Join" : [ "", [
-                                                " --env \"",
-                                                { "Ref" : "WatchmakerEnvironment" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseOuPath",
-                                            { "Fn::Join" : [ "", [
-                                                " --oupath \"",
-                                                { "Ref" : "WatchmakerOuPath" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseComputerName",
-                                            { "Fn::Join" : [ "", [
-                                                " --computer-name \"",
-                                                { "Ref" : "WatchmakerComputerName" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseAdminGroups",
-                                            { "Fn::Join" : [ "", [
-                                                " --admin-groups \"",
-                                                { "Ref" : "WatchmakerAdminGroups" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseAdminUsers",
-                                            { "Fn::Join" : [ "", [
-                                                " --admin-users \"",
-                                                { "Ref" : "WatchmakerAdminUsers" },
-                                                "\""
-                                            ]]},
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseS3Source",
-                                            " --s3-source",
-                                            ""
-                                        ]
-                                    }
-                                ]]}
-                            }
-                        }
-                    },
-                    "make-app" :
-                    {
-                        "commands" :
-                        {
-                            "05-get-appscript" :
-                            {
-                                "command" :
-                                { "Fn::Join" : [ "", [
-                                    "mkdir -p /etc/cfn/scripts &&",
-                                    " aws s3 cp ",
-                                    { "Ref" : "AppScriptUrl" },
-                                    " /etc/cfn/scripts/make-app",
-                                    " --region ",
-                                    { "Ref" : "AWS::Region" }, " &&",
-                                    " chown root:root /etc/cfn/scripts/make-app &&",
-                                    " chmod 700 /etc/cfn/scripts/make-app"
-                                ]]},
-                                "env" :
-                                {
-                                  "AWS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt",
-                                  "REQUESTS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt"
-                                }
-                            },
-                            "10-make-app" :
-                            {
-                                "command" :
-                                { "Fn::Join" : [ "", [
-                                    { "Ref" : "AppScriptShell" },
-                                    " /etc/cfn/scripts/make-app ",
-                                    { "Ref" : "AppScriptParams" }
-                                ]]},
-                                "env" :
-                                {
-                                  "AWS_DEFAULT_REGION" : { "Ref" : "AWS::Region" },
-                                  "AWS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt",
-                                  "REQUESTS_CA_BUNDLE" : "/etc/pki/tls/certs/ca-bundle.crt"
-                                }
-                            }
-                        }
-                    },
-                    "finalize" :
-                    {
-                        "commands" :
-                        {
-                            "10-signal-success" :
-                            {
-                                "command" :
-                                { "Fn::Join" : [ "", [
-                                    "/opt/aws/bin/cfn-signal -e 0",
-                                    " --stack ", { "Ref" : "AWS::StackName" },
-                                    " --resource WatchmakerInstance",
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "AssignInstanceRole",
-                                            { "Fn::Join" : [ "", [
-                                                " --role ",
-                                                { "Ref" : "InstanceRole" }
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    {
-                                        "Fn::If" :
-                                        [
-                                            "UseCfnUrl",
-                                            { "Fn::Join" : [ "", [
-                                                " --url ",
-                                                { "Ref" : "CfnEndpointUrl" }
-                                            ] ] },
-                                            ""
-                                        ]
-                                    },
-                                    " --region ", { "Ref" : "AWS::Region"}, "\n"
-                                ]]},
-                                "ignoreErrors" : "true"
-                            }
-                        }
-                    },
-                    "reboot" :
-                    {
-                        "commands" :
-                        {
-                            "10-reboot" :
-                            {
-                                "command" : "shutdown -r +1 &"
-                            }
-                        }
-                    }
-                }
-            },
-            "Properties" :
-            {
-                "ImageId" : { "Ref" : "AmiId" },
-                "InstanceType" : { "Ref" : "InstanceType" },
-                "IamInstanceProfile" :
-                {
-                    "Fn::If" :
-                    [
-                        "AssignInstanceRole",
-                        { "Ref" : "InstanceRole" },
-                        { "Ref" : "AWS::NoValue" }
-                    ]
-                },
-                "Tags" :
-                [
-                    {
-                        "Key" : "Name",
-                        "Value" :
-                        { "Fn::Join" : [ "", [
-                            { "Ref" : "AWS::StackName" }
-                        ]]}
-                    }
-                ],
-                "BlockDeviceMappings" :
-                [
-                    {
-                        "DeviceName" :
-                        { "Fn::Join" : [ "", [
-                            "/dev/",
-                            { "Fn::FindInMap" :
-                                [
-                                    "Distro2RootDevice",
-                                    { "Ref" : "AmiDistro" },
-                                    "DeviceName"
-                                ]
-                            }
-                        ]]},
-                        "Ebs" :
-                        {
-                            "VolumeType" : "gp2",
-                            "DeleteOnTermination" : "true"
-                        }
-                    },
-                    {
-                        "Fn::If" :
-                        [
-                            "CreateAppVolume",
-                            {
-                                "DeviceName" : { "Ref" : "AppVolumeDevice" },
-                                "Ebs" :
-                                {
-                                    "VolumeSize" : { "Ref" : "AppVolumeSize" },
-                                    "VolumeType" : { "Ref" : "AppVolumeType" },
-                                    "DeleteOnTermination" : "true"
-                                }
-                            },
-                            { "Ref" : "AWS::NoValue" }
-                        ]
-                    }
-                ],
-                "KeyName" :
-                {
-                    "Ref" : "KeyPairName"
-                },
-                "NetworkInterfaces":
-                [
-                    {
-                        "DeviceIndex" : "0",
-                        "AssociatePublicIpAddress" :
-                        {
-                            "Fn::If" :
-                            [
-                                "AssignPublicIp",
-                                "true",
-                                "false"
-                            ]
-                        },
-                        "PrivateIpAddress" :
-                        {
-                            "Fn::If" :
-                            [
-                                "AssignStaticPrivateIp",
-                                { "Ref" : "PrivateIp" },
-                                { "Ref" : "AWS::NoValue" }
-                            ]
-                        },
-                        "GroupSet" : { "Ref": "SecurityGroupIds" },
-                        "SubnetId": { "Ref" : "SubnetId" }
-                    }
-                ],
-                "UserData" :
-                {
-                    "Fn::Base64" :
-                    { "Fn::Join" : [ "", [
-                        "Content-Type: multipart/mixed; boundary=\"===============3585321300151562773==\"\n",
-                        "MIME-Version: 1.0\n",
-                        "\n",
-
-                        "--===============3585321300151562773==\n",
-                        "Content-Type: text/cloud-config; charset=\"us-ascii\"\n",
-                        "MIME-Version: 1.0\n",
-                        "Content-Transfer-Encoding: 7bit\n",
-                        "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
-                        "\n",
-
-                        "#cloud-config\n",
-                        {
-                            "Fn::If" :
-                            [
-                                "CreateAppVolume",
-                                { "Fn::Join" : [ "", [
-                                    "bootcmd:\n",
-                                    "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
-                                    { "Ref" : "AppVolumeDevice" },
-                                    "\n",
-                                    "mounts:\n",
-                                    "- [ ",
-                                    { "Ref" : "AppVolumeDevice" }, ", ",
-                                    { "Ref" : "AppVolumeMountPath" },
-                                    " ]\n"
-                                ]]},
-                                { "Ref" : "AWS::NoValue" }
-                            ]
-                        },
-
-                        "\n",
-
-                        "--===============3585321300151562773==\n",
-                        "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
-                        "MIME-Version: 1.0\n",
-                        "Content-Transfer-Encoding: 7bit\n",
-                        "Content-Disposition: attachment; filename=\"script.sh\"\n",
-                        "\n",
-
-                        "#!/bin/bash -xe\n\n",
-
-                        "# Export cert bundle ENVs\n",
-                        "export AWS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
-                        "export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n\n",
-
-                        "# Get pip\n",
-                        "curl --silent --show-error --retry 5 -L ",
-                        { "Ref" : "CfnGetPipUrl" },
-                        " | python - --index-url=", { "Ref" : "PypiIndexUrl" }, "\n\n",
-
-                        "# Add pip to path\n",
-                        "hash pip 2> /dev/null || ",
-                        "PATH=\"${PATH}:/usr/local/bin\"", "\n\n",
-
-                        "# Upgrade pip and setuptools\n",
-                        "PYPI_URL=", { "Ref" : "PypiIndexUrl" }, "\n",
-                        "pip install",
-                        " --index-url=\"$PYPI_URL\"",
-                        " --upgrade pip setuptools\n\n",
-
-                        "# Fix python urllib3 warnings\n",
-                        "yum -y install gcc python-devel libffi-devel openssl-devel\n",
-                        "pip install",
-                        " --index-url=\"$PYPI_URL\"",
-                        " --upgrade pyopenssl ndg-httpsclient pyasn1\n\n",
-
-                        "# Get cfn utils\n",
-                        "pip install",
-                        " --index-url=\"$PYPI_URL\"",
-                        " --upgrade ",
-                        { "Ref" : "CfnBootstrapUtilsUrl" },
-                        "\n\n",
-
-                        "# Remove gcc now that it is no longer needed\n",
-                        "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
-
-                        "# Fixup cfn utils\n",
-                        "INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat ",
-                        "2> /dev/null || echo /usr/init/redhat)\n",
-                        "chmod 775 ${INITDIR}/cfn-hup\n",
-                        "ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
-                        "chkconfig --add cfn-hup\n",
-                        "chkconfig cfn-hup on\n",
-                        "mkdir -p /opt/aws/bin\n",
-                        "BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin ",
-                        "2> /dev/null || echo /usr/bin)\n",
-                        "for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup ",
-                        "cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
-                        "do\n",
-                        "    ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
-                        "    echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
-                        "done\n\n",
-
-                        "# Add cfn-signal to path\n",
-                        "hash cfn-signal 2> /dev/null || ",
-                        "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
-                        "\n\n",
-
-                        "# Execute cfn-init\n",
-                        "/opt/aws/bin/cfn-init -v -c launch",
-                        " --stack ", { "Ref" : "AWS::StackName" },
-                        " --resource WatchmakerInstance",
-                        {
-                            "Fn::If" :
-                            [
-                                "AssignInstanceRole",
-                                { "Fn::Join" : [ "", [
-                                    " --role ", { "Ref" : "InstanceRole" }
-                                ] ] },
-                                ""
-                            ]
-                        },
-                        {
-                            "Fn::If" :
-                            [
-                                "UseCfnUrl",
-                                { "Fn::Join" : [ "", [
-                                    " --url ", { "Ref" : "CfnEndpointUrl" }
-                                ] ] },
-                                ""
-                            ]
-                        },
-                        " --region ", { "Ref" : "AWS::Region" }, " ||",
-                        " ( echo 'ERROR: cfn-init failed! Aborting!';",
-                        " /opt/aws/bin/cfn-signal -e 1",
-                        "  --stack ", { "Ref" : "AWS::StackName" },
-                        "  --resource WatchmakerInstance",
-                        {
-                            "Fn::If" :
-                            [
-                                "AssignInstanceRole",
-                                { "Fn::Join" : [ "", [
-                                    " --role ", { "Ref" : "InstanceRole" }
-                                ] ] },
-                                ""
-                            ]
-                        },
-                        {
-                            "Fn::If" :
-                            [
-                                "UseCfnUrl",
-                                { "Fn::Join" : [ "", [
-                                    " --url ", { "Ref" : "CfnEndpointUrl" }
-                                ] ] },
-                                ""
-                            ]
-                        },
-                        "  --region ", { "Ref" : "AWS::Region"}, ";",
-                        " exit 1",
-                        " )\n\n",
-                        "--===============3585321300151562773==--"
-                    ] ] }
-                }
-            }
-        }
+      "Description": "(Optional) S3 URL to the application script in an S3 bucket (s3://). Leave blank to launch without an application script. If specified, an appropriate \"InstanceRole\" is required",
+      "Type": "String",
+      "Default": "",
+      "AllowedPattern": "^$|^s3://(.*)$",
+      "ConstraintDescription": "Must use an S3 URL (starts with \"s3://\")"
     },
-    "Outputs" :
+    "AppVolumeDevice":
     {
-        "WatchmakerInstanceId" :
-        {
-            "Value" : { "Ref" : "WatchmakerInstance" },
-            "Description" : "Instance ID"
-        }
+      "Description": "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume",
+      "Type": "String",
+      "Default": "",
+      "AllowedValues":
+      [
+        "",
+        "/dev/xvdf",
+        "/dev/xvdg",
+        "/dev/xvdh",
+        "/dev/xvdi",
+        "/dev/xvdj"
+      ]
+    },
+    "AppVolumeMountPath":
+    {
+      "Description": "Filesystem path to mount the extra app volume. Ignored if \"AppVolumeDevice\" is blank",
+      "Type": "String",
+      "Default": "/opt/data",
+      "AllowedPattern": "/.*"
+    },
+    "AppVolumeType":
+    {
+      "Description": "Type of EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+      "Type": "String",
+      "Default": "gp2",
+      "AllowedValues":
+      [
+        "gp2",
+        "io1",
+        "sc1",
+        "st1",
+        "standard"
+      ]
+    },
+    "AppVolumeSize":
+    {
+      "Description": "Size in GB of the EBS volume to create. Ignored if \"AppVolumeDevice\" is blank",
+      "Type": "Number",
+      "Default": "1",
+      "MinValue": "1",
+      "MaxValue": "16384",
+      "ConstraintDescription": "Must be between 1GB and 16384GB."
+    },
+    "KeyPairName":
+    {
+      "Description": "Public/private key pairs allow you to securely connect to your instance after it launches",
+      "Type": "AWS::EC2::KeyPair::KeyName"
+    },
+    "InstanceType":
+    {
+      "Description": "Amazon EC2 instance type",
+      "Type": "String",
+      "Default": "t2.micro",
+      "AllowedValues":
+      [
+        "t2.micro",
+        "t2.small",
+        "t2.medium",
+        "t2.large",
+        "c4.large",
+        "c4.xlarge",
+        "m4.large",
+        "m4.xlarge"
+      ]
+    },
+    "InstanceRole":
+    {
+      "Description": "(Optional) IAM instance role to apply to the instance",
+      "Type": "String",
+      "Default": ""
+    },
+    "PrivateIp":
+    {
+      "Description": "(Optional) Set a static, primary private IP. Leave blank to auto-select a free IP",
+      "Type": "String",
+      "Default": ""
+    },
+    "NoPublicIp":
+    {
+      "Description": "Controls whether to assign the instance a public IP. Recommended to leave at \"true\" _unless_ launching in a public subnet",
+      "Type": "String",
+      "Default": "true",
+      "AllowedValues":
+      [
+        "false",
+        "true"
+      ]
+    },
+    "NoReboot":
+    {
+      "Description": "Controls whether to reboot the instance as the last step of cfn-init execution",
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues":
+      [
+        "false",
+        "true"
+      ]
+    },
+    "NoUpdates":
+    {
+      "Description": "Controls whether to run yum update during a stack update (on the initial instance launch, Watchmaker _always_ installs updates)",
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues":
+      [
+        "false",
+        "true"
+      ]
+    },
+    "SecurityGroupIds":
+    {
+      "Description": "List of security groups to apply to the instance",
+      "Type": "List<AWS::EC2::SecurityGroup::Id>"
+    },
+    "SubnetId":
+    {
+      "Type": "AWS::EC2::Subnet::Id",
+      "Description": "ID of the subnet to assign to the instance"
+    },
+    "PypiIndexUrl":
+    {
+      "Description": "URL to the PyPi Index",
+      "Type": "String",
+      "Default": "https://pypi.org/simple",
+      "AllowedPattern": "^http[s]?://.*$"
+    },
+    "WatchmakerConfig":
+    {
+      "Description": "(Optional) URL to a Watchmaker config file",
+      "Type": "String",
+      "Default": "",
+      "AllowedPattern": "^$|^http[s]?://.*$"
+    },
+    "WatchmakerEnvironment":
+    {
+      "Description": "Environment in which the instance is being deployed",
+      "Type": "String",
+      "Default": "",
+      "AllowedValues":
+      [
+        "",
+        "dev",
+        "test",
+        "prod"
+      ]
+    },
+    "WatchmakerOuPath":
+    {
+      "Description": "(Optional) DN of the OU to place the instance when joining a domain. If blank and \"WatchmakerEnvironment\" enforces a domain join, the instance will be placed in a default container. Leave blank if not joining a domain, or if \"WatchmakerEnvironment\" is \"false\"",
+      "Type": "String",
+      "Default": "",
+      "AllowedPattern": "^$|^(OU=.+,)+(DC=.+)+$"
+    },
+    "WatchmakerComputerName":
+    {
+      "Description": "(Optional) Sets the hostname/computername within the OS",
+      "Type": "String",
+      "Default": ""
+    },
+    "WatchmakerAdminGroups":
+    {
+      "Description": "(Optional) Colon-separated list of domain groups that should have admin permissions on the EC2 instance",
+      "Type": "String",
+      "Default": ""
+    },
+    "WatchmakerAdminUsers":
+    {
+      "Description": "(Optional) Colon-separated list of domain users that should have admin permissions on the EC2 instance",
+      "Type": "String",
+      "Default": ""
+    },
+    "WatchmakerS3Source":
+    {
+      "Description": "Flag that tells watchmaker to use its instance role to retrieve watchmaker content from S3",
+      "Type": "String",
+      "Default": "false",
+      "AllowedValues":
+      [
+        "false",
+        "true"
+      ]
+    },
+    "CfnEndpointUrl":
+    {
+      "Description": "(Optional) URL to the CloudFormation Endpoint. e.g. https://cloudformation.us-east-1.amazonaws.com",
+      "Type": "String",
+      "Default": "https://cloudformation.us-east-1.amazonaws.com",
+      "AllowedPattern": "^$|^http[s]?://.*$"
+    },
+    "CfnGetPipUrl":
+    {
+      "Description": "URL to get-pip.py",
+      "Type": "String",
+      "Default": "https://bootstrap.pypa.io/get-pip.py",
+      "AllowedPattern": "^http[s]?://.*\\.py$"
+    },
+    "CfnBootstrapUtilsUrl":
+    {
+      "Description": "URL to aws-cfn-bootstrap-latest.tar.gz",
+      "Type": "String",
+      "Default": "https://s3.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-latest.tar.gz",
+      "AllowedPattern": "^http[s]?://.*\\.tar\\.gz$"
+    },
+    "ToggleCfnInitUpdate":
+    {
+      "Description": "A/B toggle that forces a change to instance metadata, triggering the cfn-init update sequence",
+      "Type": "String",
+      "Default": "A",
+      "AllowedValues":
+      [
+        "A",
+        "B"
+      ]
     }
+  },
+  "Conditions":
+  {
+    "ExecuteAppScript":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "AppScriptUrl" }, "" ] } ]
+    },
+    "CreateAppVolume":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "AppVolumeDevice" }, "" ] } ]
+    },
+    "UseWamConfig":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerConfig" }, "" ] } ]
+    },
+    "UseOuPath":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerOuPath" }, "" ] } ]
+    },
+    "UseComputerName":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerComputerName" }, "" ] } ]
+    },
+    "UseAdminGroups":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerAdminGroups" }, "" ] } ]
+    },
+    "UseAdminUsers":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerAdminUsers" }, "" ] } ]
+    },
+    "UseS3Source":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerS3Source" }, "false" ] } ]
+    },
+    "UseEnvironment":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "WatchmakerEnvironment" }, "" ] } ]
+    },
+    "UseCfnUrl":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "CfnEndpointUrl" }, "" ] } ]
+    },
+    "InstallUpdates":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "NoUpdates" }, "true" ] } ]
+    },
+    "Reboot":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "NoReboot" }, "true" ] } ]
+    },
+    "AssignInstanceRole":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "InstanceRole" }, "" ] } ]
+    },
+    "AssignStaticPrivateIp":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "PrivateIp" }, "" ] } ]
+    },
+    "AssignPublicIp":
+    {
+      "Fn::Not": [ { "Fn::Equals": [ { "Ref": "NoPublicIp" }, "true" ] } ]
+    }
+  },
+  "Mappings":
+  {
+    "Distro2RootDevice":
+    {
+      "AmazonLinux": { "DeviceName": "xvda" },
+      "RedHat": { "DeviceName": "sda1" },
+      "CentOS": { "DeviceName": "sda1" }
+    }
+  },
+  "Metadata":
+  {
+    "AWS::CloudFormation::Interface":
+    {
+      "ParameterGroups":
+      [
+        {
+          "Label":
+          {
+            "default": "EC2 Instance Configuration"
+          },
+          "Parameters":
+          [
+            "AmiId",
+            "AmiDistro",
+            "InstanceType",
+            "InstanceRole",
+            "KeyPairName",
+            "NoPublicIp",
+            "NoReboot",
+            "NoUpdates",
+            "SecurityGroupIds"
+          ]
+        },
+        {
+          "Label":
+          {
+            "default": "EC2 Watchmaker Configuration"
+          },
+          "Parameters":
+          [
+            "PypiIndexUrl",
+            "WatchmakerConfig",
+            "WatchmakerEnvironment",
+            "WatchmakerOuPath",
+            "WatchmakerComputerName",
+            "WatchmakerAdminGroups",
+            "WatchmakerAdminUsers",
+            "WatchmakerS3Source"
+          ]
+        },
+        {
+          "Label":
+          {
+            "default": "EC2 Application Configuration"
+          },
+          "Parameters":
+          [
+            "AppScriptUrl",
+            "AppScriptParams",
+            "AppScriptShell"
+          ]
+        },
+        {
+          "Label":
+          {
+            "default": "EC2 Application EBS Volume"
+          },
+          "Parameters":
+          [
+            "AppVolumeDevice",
+            "AppVolumeMountPath",
+            "AppVolumeSize",
+            "AppVolumeType"
+          ]
+        },
+        {
+          "Label":
+          {
+            "default": "Network Configuration"
+          },
+          "Parameters":
+          [
+            "PrivateIp",
+            "SubnetId"
+          ]
+        },
+        {
+          "Label":
+          {
+            "default": "CloudFormation Configuration"
+          },
+          "Parameters":
+          [
+            "CfnEndpointUrl",
+            "CfnGetPipUrl",
+            "CfnBootstrapUtilsUrl",
+            "ToggleCfnInitUpdate"
+          ]
+        }
+      ],
+      "ParameterLabels":
+      {
+        "ToggleCfnInitUpdate":
+        {
+          "default": "Force Cfn Init Update"
+        }
+      }
+    }
+  },
+  "Resources":
+  {
+    "WatchmakerInstance":
+    {
+      "Type": "AWS::EC2::Instance",
+      "CreationPolicy":
+      {
+        "ResourceSignal":
+        {
+          "Count": "1",
+          "Timeout": "PT30M"
+        }
+      },
+      "Metadata": {
+        "ToggleCfnInitUpdate": { "Ref": "ToggleCfnInitUpdate" },
+        "AWS::CloudFormation::Init":
+        {
+          "configSets":
+          {
+            "launch":
+            [
+              "setup",
+              "watchmaker-install",
+              "watchmaker-launch",
+              {
+                "Fn::If":
+                [
+                  "ExecuteAppScript",
+                  "make-app",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
+              "finalize",
+              {
+                "Fn::If":
+                [
+                  "Reboot",
+                  "reboot",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              }
+            ],
+            "update":
+            [
+              "setup",
+              {
+                "Fn::If":
+                [
+                  "InstallUpdates",
+                  "install-updates",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
+              "watchmaker-install",
+              "watchmaker-update",
+              {
+                "Fn::If":
+                [
+                  "ExecuteAppScript",
+                  "make-app",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              },
+              "finalize",
+              {
+                "Fn::If":
+                [
+                  "Reboot",
+                  "reboot",
+                  { "Ref": "AWS::NoValue" }
+                ]
+              }
+            ]
+          },
+          "setup":
+          {
+            "files":
+            {
+              "/etc/cfn/cfn-hup.conf":
+              {
+                "content":
+                { "Fn::Join": ["", [
+                  "[main]\n",
+                  "stack=", { "Ref": "AWS::StackId" }, "\n",
+                  "region=", { "Ref": "AWS::Region" }, "\n",
+                  {
+                    "Fn::If":
+                    [
+                      "AssignInstanceRole",
+                      { "Fn::Join": [ "", [
+                        "role=",
+                        { "Ref": "InstanceRole" },
+                        "\n"
+                      ] ] },
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseCfnUrl",
+                      { "Fn::Join": [ "", [
+                        "url=",
+                        { "Ref": "CfnEndpointUrl" },
+                        "\n"
+                      ] ] },
+                      ""
+                    ]
+                  },
+                  "interval=1", "\n",
+                  "verbose=true", "\n"
+                ]]},
+                "mode"  : "000400",
+                "owner"   : "root",
+                "group"   : "root"
+              },
+              "/etc/cfn/hooks.d/cfn-auto-reloader.conf":
+              {
+                "content":
+                { "Fn::Join": ["", [
+                  "[cfn-auto-reloader-hook]\n",
+                  "triggers=post.update\n",
+                  "path=Resources.WatchmakerInstance.Metadata\n",
+                  "action=/opt/aws/bin/cfn-init -v -c update",
+                  " --stack ", { "Ref": "AWS::StackName" },
+                  " --resource WatchmakerInstance",
+                  {
+                    "Fn::If":
+                    [
+                      "AssignInstanceRole",
+                      { "Fn::Join": [ "", [
+                        " --role ",
+                        { "Ref": "InstanceRole" }
+                      ] ] },
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseCfnUrl",
+                      { "Fn::Join": [ "", [
+                        " --url ",
+                        { "Ref": "CfnEndpointUrl" }
+                      ] ] },
+                      ""
+                    ]
+                  },
+                  " --region ", { "Ref": "AWS::Region" }, "\n",
+                  "runas=root\n"
+                ]]},
+                "mode": "000400",
+                "owner": "root",
+                "group": "root"
+              },
+              "/etc/cfn/scripts/watchmaker-install.sh":
+              {
+                "content":
+                { "Fn::Join": [ "", [
+                  "#!/bin/bash\n\n",
+
+                  "PYPI_URL=", { "Ref": "PypiIndexUrl" }, "\n",
+
+                  "pip install --index-url=\"$PYPI_URL\" wheel==0.29.0\n",
+
+                  "pip install",
+                  " --index-url=\"$PYPI_URL\"",
+                  " --upgrade pip setuptools boto3 watchmaker\n\n"
+                ]]},
+                "mode": "000700",
+                "owner": "root",
+                "group": "root"
+              }
+            },
+            "services":
+            {
+              "sysvinit":
+              {
+                "cfn-hup":
+                {
+                  "enabled": "true",
+                  "ensureRunning": "true",
+                  "files":
+                  [
+                    "/etc/cfn/cfn-hup.conf",
+                    "/etc/cfn/hooks.d/cfn-auto-reloader.conf"
+                  ]
+                }
+              }
+            }
+          },
+          "install-updates":
+          {
+            "commands":
+            {
+              "10-install-updates":
+              {
+                "command": "yum -y update"
+              }
+            }
+          },
+          "watchmaker-install":
+          {
+            "commands":
+            {
+              "10-watchmaker-install":
+              {
+                "command": "bash -xe /etc/cfn/scripts/watchmaker-install.sh",
+                "env":
+                {
+                  "AWS_DEFAULT_REGION": { "Ref": "AWS::Region" },
+                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
+                  "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
+                }
+              }
+            }
+          },
+          "watchmaker-launch":
+          {
+            "commands":
+            {
+              "10-watchmaker-launch":
+              {
+                "command":
+                { "Fn::Join": [ "", [
+                  "watchmaker --log-level debug",
+                  " --log-dir /var/log/watchmaker",
+                  " --no-reboot",
+                  {
+                    "Fn::If":
+                    [
+                      "UseWamConfig",
+                      { "Fn::Join": [ "", [
+                        " --config \"",
+                        { "Ref": "WatchmakerConfig" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseEnvironment",
+                      { "Fn::Join": [ "", [
+                        " --env \"",
+                        { "Ref": "WatchmakerEnvironment" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseOuPath",
+                      { "Fn::Join": [ "", [
+                        " --ou-path \"",
+                        { "Ref": "WatchmakerOuPath" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseComputerName",
+                      { "Fn::Join": [ "", [
+                        " --computer-name \"",
+                        { "Ref": "WatchmakerComputerName" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseAdminGroups",
+                      { "Fn::Join": [ "", [
+                        " --admin-groups \"",
+                        { "Ref": "WatchmakerAdminGroups" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseAdminUsers",
+                      { "Fn::Join": [ "", [
+                        " --admin-users \"",
+                        { "Ref": "WatchmakerAdminUsers" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseS3Source",
+                      " --s3-source",
+                      ""
+                    ]
+                  }
+                ]]}
+              }
+            }
+          },
+          "watchmaker-update":
+          {
+            "commands":
+            {
+              "10-watchmaker-update":
+              {
+                "command":
+                { "Fn::Join": [ "", [
+                  "watchmaker --log-level debug",
+                  " --log-dir /var/log/watchmaker",
+                  " --salt-states None",
+                  " --no-reboot",
+                  {
+                    "Fn::If":
+                    [
+                      "UseWamConfig",
+                      { "Fn::Join": [ "", [
+                        " --config \"",
+                        { "Ref": "WatchmakerConfig" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseEnvironment",
+                      { "Fn::Join": [ "", [
+                        " --env \"",
+                        { "Ref": "WatchmakerEnvironment" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseOuPath",
+                      { "Fn::Join": [ "", [
+                        " --oupath \"",
+                        { "Ref": "WatchmakerOuPath" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseComputerName",
+                      { "Fn::Join": [ "", [
+                        " --computer-name \"",
+                        { "Ref": "WatchmakerComputerName" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseAdminGroups",
+                      { "Fn::Join": [ "", [
+                        " --admin-groups \"",
+                        { "Ref": "WatchmakerAdminGroups" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseAdminUsers",
+                      { "Fn::Join": [ "", [
+                        " --admin-users \"",
+                        { "Ref": "WatchmakerAdminUsers" },
+                        "\""
+                      ]]},
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseS3Source",
+                      " --s3-source",
+                      ""
+                    ]
+                  }
+                ]]}
+              }
+            }
+          },
+          "make-app":
+          {
+            "commands":
+            {
+              "05-get-appscript":
+              {
+                "command":
+                { "Fn::Join": [ "", [
+                  "mkdir -p /etc/cfn/scripts &&",
+                  " aws s3 cp ",
+                  { "Ref": "AppScriptUrl" },
+                  " /etc/cfn/scripts/make-app",
+                  " --region ",
+                  { "Ref": "AWS::Region" }, " &&",
+                  " chown root:root /etc/cfn/scripts/make-app &&",
+                  " chmod 700 /etc/cfn/scripts/make-app"
+                ]]},
+                "env":
+                {
+                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
+                  "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
+                }
+              },
+              "10-make-app":
+              {
+                "command":
+                { "Fn::Join": [ "", [
+                  { "Ref": "AppScriptShell" },
+                  " /etc/cfn/scripts/make-app ",
+                  { "Ref": "AppScriptParams" }
+                ]]},
+                "env":
+                {
+                  "AWS_DEFAULT_REGION": { "Ref": "AWS::Region" },
+                  "AWS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt",
+                  "REQUESTS_CA_BUNDLE": "/etc/pki/tls/certs/ca-bundle.crt"
+                }
+              }
+            }
+          },
+          "finalize":
+          {
+            "commands":
+            {
+              "10-signal-success":
+              {
+                "command":
+                { "Fn::Join": [ "", [
+                  "/opt/aws/bin/cfn-signal -e 0",
+                  " --stack ", { "Ref": "AWS::StackName" },
+                  " --resource WatchmakerInstance",
+                  {
+                    "Fn::If":
+                    [
+                      "AssignInstanceRole",
+                      { "Fn::Join": [ "", [
+                        " --role ",
+                        { "Ref": "InstanceRole" }
+                      ] ] },
+                      ""
+                    ]
+                  },
+                  {
+                    "Fn::If":
+                    [
+                      "UseCfnUrl",
+                      { "Fn::Join": [ "", [
+                        " --url ",
+                        { "Ref": "CfnEndpointUrl" }
+                      ] ] },
+                      ""
+                    ]
+                  },
+                  " --region ", { "Ref": "AWS::Region"}, "\n"
+                ]]},
+                "ignoreErrors": "true"
+              }
+            }
+          },
+          "reboot":
+          {
+            "commands":
+            {
+              "10-reboot":
+              {
+                "command": "shutdown -r +1 &"
+              }
+            }
+          }
+        }
+      },
+      "Properties":
+      {
+        "ImageId": { "Ref": "AmiId" },
+        "InstanceType": { "Ref": "InstanceType" },
+        "IamInstanceProfile":
+        {
+          "Fn::If":
+          [
+            "AssignInstanceRole",
+            { "Ref": "InstanceRole" },
+            { "Ref": "AWS::NoValue" }
+          ]
+        },
+        "Tags":
+        [
+          {
+            "Key": "Name",
+            "Value":
+            { "Fn::Join": [ "", [
+              { "Ref": "AWS::StackName" }
+            ]]}
+          }
+        ],
+        "BlockDeviceMappings":
+        [
+          {
+            "DeviceName":
+            { "Fn::Join": [ "", [
+              "/dev/",
+              { "Fn::FindInMap":
+                [
+                  "Distro2RootDevice",
+                  { "Ref": "AmiDistro" },
+                  "DeviceName"
+                ]
+              }
+            ]]},
+            "Ebs":
+            {
+              "VolumeType": "gp2",
+              "DeleteOnTermination": "true"
+            }
+          },
+          {
+            "Fn::If":
+            [
+              "CreateAppVolume",
+              {
+                "DeviceName": { "Ref": "AppVolumeDevice" },
+                "Ebs":
+                {
+                  "VolumeSize": { "Ref": "AppVolumeSize" },
+                  "VolumeType": { "Ref": "AppVolumeType" },
+                  "DeleteOnTermination": "true"
+                }
+              },
+              { "Ref": "AWS::NoValue" }
+            ]
+          }
+        ],
+        "KeyName":
+        {
+          "Ref": "KeyPairName"
+        },
+        "NetworkInterfaces":
+        [
+          {
+            "DeviceIndex": "0",
+            "AssociatePublicIpAddress":
+            {
+              "Fn::If":
+              [
+                "AssignPublicIp",
+                "true",
+                "false"
+              ]
+            },
+            "PrivateIpAddress":
+            {
+              "Fn::If":
+              [
+                "AssignStaticPrivateIp",
+                { "Ref": "PrivateIp" },
+                { "Ref": "AWS::NoValue" }
+              ]
+            },
+            "GroupSet": { "Ref": "SecurityGroupIds" },
+            "SubnetId": { "Ref": "SubnetId" }
+          }
+        ],
+        "UserData":
+        {
+          "Fn::Base64":
+          { "Fn::Join": [ "", [
+            "Content-Type: multipart/mixed; boundary=\"===============3585321300151562773==\"\n",
+            "MIME-Version: 1.0\n",
+            "\n",
+
+            "--===============3585321300151562773==\n",
+            "Content-Type: text/cloud-config; charset=\"us-ascii\"\n",
+            "MIME-Version: 1.0\n",
+            "Content-Transfer-Encoding: 7bit\n",
+            "Content-Disposition: attachment; filename=\"cloud.cfg\"\n",
+            "\n",
+
+            "#cloud-config\n",
+            {
+              "Fn::If":
+              [
+                "CreateAppVolume",
+                { "Fn::Join": [ "", [
+                  "bootcmd:\n",
+                  "- cloud-init-per instance mkfs-appvolume mkfs -t ext4 ",
+                  { "Ref": "AppVolumeDevice" },
+                  "\n",
+                  "mounts:\n",
+                  "- [ ",
+                  { "Ref": "AppVolumeDevice" }, ", ",
+                  { "Ref": "AppVolumeMountPath" },
+                  " ]\n"
+                ]]},
+                { "Ref": "AWS::NoValue" }
+              ]
+            },
+
+            "\n",
+
+            "--===============3585321300151562773==\n",
+            "Content-Type: text/x-shellscript; charset=\"us-ascii\"\n",
+            "MIME-Version: 1.0\n",
+            "Content-Transfer-Encoding: 7bit\n",
+            "Content-Disposition: attachment; filename=\"script.sh\"\n",
+            "\n",
+
+            "#!/bin/bash -xe\n\n",
+
+            "# Export cert bundle ENVs\n",
+            "export AWS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n",
+            "export REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt\n\n",
+
+            "# Get pip\n",
+            "curl --silent --show-error --retry 5 -L ",
+            { "Ref": "CfnGetPipUrl" },
+            " | python - --index-url=", { "Ref": "PypiIndexUrl" }, "\n\n",
+
+            "# Add pip to path\n",
+            "hash pip 2> /dev/null || ",
+            "PATH=\"${PATH}:/usr/local/bin\"", "\n\n",
+
+            "# Upgrade pip and setuptools\n",
+            "PYPI_URL=", { "Ref": "PypiIndexUrl" }, "\n",
+            "pip install",
+            " --index-url=\"$PYPI_URL\"",
+            " --upgrade pip setuptools\n\n",
+
+            "# Fix python urllib3 warnings\n",
+            "yum -y install gcc python-devel libffi-devel openssl-devel\n",
+            "pip install",
+            " --index-url=\"$PYPI_URL\"",
+            " --upgrade pyopenssl ndg-httpsclient pyasn1\n\n",
+
+            "# Get cfn utils\n",
+            "pip install",
+            " --index-url=\"$PYPI_URL\"",
+            " --upgrade ",
+            { "Ref": "CfnBootstrapUtilsUrl" },
+            "\n\n",
+
+            "# Remove gcc now that it is no longer needed\n",
+            "yum -y remove gcc --setopt=clean_requirements_on_remove=1\n\n",
+
+            "# Fixup cfn utils\n",
+            "INITDIR=$(find -L /opt/aws/apitools/cfn-init/init -name redhat ",
+            "2> /dev/null || echo /usr/init/redhat)\n",
+            "chmod 775 ${INITDIR}/cfn-hup\n",
+            "ln -f -s ${INITDIR}/cfn-hup /etc/rc.d/init.d/cfn-hup\n",
+            "chkconfig --add cfn-hup\n",
+            "chkconfig cfn-hup on\n",
+            "mkdir -p /opt/aws/bin\n",
+            "BINDIR=$(find -L /opt/aws/apitools/cfn-init -name bin ",
+            "2> /dev/null || echo /usr/bin)\n",
+            "for SCRIPT in cfn-elect-cmd-leader cfn-get-metadata cfn-hup ",
+            "cfn-init cfn-send-cmd-event cfn-send-cmd-result cfn-signal\n",
+            "do\n",
+            "  ln -s ${BINDIR}/${SCRIPT} /opt/aws/bin/${SCRIPT} 2> /dev/null || ",
+            "  echo Skipped symbolic link, /opt/aws/bin/${SCRIPT} already exists\n",
+            "done\n\n",
+
+            "# Add cfn-signal to path\n",
+            "hash cfn-signal 2> /dev/null || ",
+            "PATH=\"${PATH}:/usr/local/bin:/opt/aws/bin\"",
+            "\n\n",
+
+            "# Execute cfn-init\n",
+            "/opt/aws/bin/cfn-init -v -c launch",
+            " --stack ", { "Ref": "AWS::StackName" },
+            " --resource WatchmakerInstance",
+            {
+              "Fn::If":
+              [
+                "AssignInstanceRole",
+                { "Fn::Join": [ "", [
+                  " --role ", { "Ref": "InstanceRole" }
+                ] ] },
+                ""
+              ]
+            },
+            {
+              "Fn::If":
+              [
+                "UseCfnUrl",
+                { "Fn::Join": [ "", [
+                  " --url ", { "Ref": "CfnEndpointUrl" }
+                ] ] },
+                ""
+              ]
+            },
+            " --region ", { "Ref": "AWS::Region" }, " ||",
+            " ( echo 'ERROR: cfn-init failed! Aborting!';",
+            " /opt/aws/bin/cfn-signal -e 1",
+            "  --stack ", { "Ref": "AWS::StackName" },
+            "  --resource WatchmakerInstance",
+            {
+              "Fn::If":
+              [
+                "AssignInstanceRole",
+                { "Fn::Join": [ "", [
+                  " --role ", { "Ref": "InstanceRole" }
+                ] ] },
+                ""
+              ]
+            },
+            {
+              "Fn::If":
+              [
+                "UseCfnUrl",
+                { "Fn::Join": [ "", [
+                  " --url ", { "Ref": "CfnEndpointUrl" }
+                ] ] },
+                ""
+              ]
+            },
+            "  --region ", { "Ref": "AWS::Region"}, ";",
+            " exit 1",
+            " )\n\n",
+            "--===============3585321300151562773==--"
+          ] ] }
+        }
+      }
+    }
+  },
+  "Outputs":
+  {
+    "WatchmakerInstanceId":
+    {
+      "Value": { "Ref": "WatchmakerInstance" },
+      "Description": "Instance ID"
+    }
+  }
 }

--- a/docs/files/templates/lx-instance/watchmaker-lx-instance.tf
+++ b/docs/files/templates/lx-instance/watchmaker-lx-instance.tf
@@ -36,8 +36,8 @@ variable "AppScriptUrl" {
 
 variable "AppVolumeDevice" {
   type        = "string"
-  description = "(Optional) Device to mount an extra EBS volume. Leave blank to launch without an extra application volume"
-  default     = ""
+  description = "Whether to mount an extra EBS volume. Leave as default (\"false\") to launch without an extra application volume"
+  default     = "false"
 }
 
 variable "AppVolumeMountPath" {


### PR DESCRIPTION
Adds mapping-keys for "internal" and "external" device-names to be used in the `UserData` and `BlockDeviceMappings` sections, respectively. Legacy instance-types get `/dev/xvdf` assigned for both values. Selectable `m5` and `c5` instance-types get `/dev/xvdf` for "external" device-name and `/dev/nvme1n1` for "internal" device-name.

Mappings have been added to both the `docs/files/templates/lx-instance/watchmaker-lx-instance.template` and `docs/files/templates/lx-autoscle/watchmaker-lx-autoscale.template` files.

Tested against `m4.large` and `m5.large` instance-types.