### PR TITLE
Uses urllib handlers to retrieve files from all source types

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,10 +73,6 @@ Parameters supported by the Salt Worker:
 -   `exclude_states` (_string, comma-separated_): States to exclude from
     execution of salt states.
 
--   `s3_source` (_boolean_): Use S3 utilities to retrieve content instead of
-    http(s) utilities. For S3 utilities to work, the system must have boto
-    credentials configured that allow access to the S3 bucket.
-
 -   `user_formulas` (_dict_): Map of formula names and URLs to zip archives of
     salt formulas. These formulas will be downloaded, extracted, and added to
     the salt file roots. The zip archive must contain a top-level directory
@@ -152,7 +148,6 @@ all:
       ou_path: None
       salt_content: https://s3.amazonaws.com/watchmaker/salt-content.zip
       salt_states: Highstate
-      s3_source: False
       user_formulas:
         # To add extra formulas, specify them as a map of
         #    <formula_name>: <archive_url>

--- a/src/watchmaker/__init__.py
+++ b/src/watchmaker/__init__.py
@@ -13,14 +13,13 @@ import subprocess
 import pkg_resources
 import setuptools
 import yaml
-from six.moves import urllib
 
 import watchmaker.utils
-import watchmaker.utils.urllib
 from watchmaker import static
 from watchmaker.exceptions import WatchmakerException
 from watchmaker.managers.workers import (LinuxWorkersManager,
                                          WindowsWorkersManager)
+from watchmaker.utils import urllib
 
 
 def _extract_version(package_name):
@@ -264,7 +263,7 @@ class Client(object):
         # Get the raw config data
         data = ''
         try:
-            data = watchmaker.utils.urllib.urlopen(self.config_path).read()
+            data = urllib.request.urlopen(self.config_path).read()
         except (ValueError, urllib.error.URLError):
             msg = (
                 'Could not read the config from {0}! Please make sure your '

--- a/src/watchmaker/__init__.py
+++ b/src/watchmaker/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals, with_statement)
 
-import codecs
 import collections
 import datetime
 import logging
@@ -20,6 +19,7 @@ from watchmaker import static
 from watchmaker.exceptions import WatchmakerException
 from watchmaker.managers.workers import (LinuxWorkersManager,
                                          WindowsWorkersManager)
+from watchmaker.utils.urllib import urlopen
 
 
 def _extract_version(package_name):
@@ -130,13 +130,6 @@ class Arguments(dict):
             of ``'Highstate'`` will apply the salt highstate.
             (*Default*: ``None``)
 
-        s3_source: (:obj:`bool`)
-            Use S3 utilities to retrieve content instead of http/s utilities.
-            For S3 utilities to work, ``boto3`` must be installed, and the
-            system must have boto credentials configured that allow access to
-            the S3 bucket.
-            (*Default*: ``None``)
-
         ou_path: (:obj:`str`)
             Set a salt grain that specifies the full DN of the OU where the
             computer account will be created when joining a domain.
@@ -180,7 +173,6 @@ class Arguments(dict):
         self.computer_name = kwargs.pop('computer_name', None)
         self.environment = kwargs.pop('environment', None)
         self.salt_states = kwargs.pop('salt_states', None)
-        self.s3_source = kwargs.pop('s3_source', None)
         self.ou_path = kwargs.pop('ou_path', None)
         self.extra_arguments = kwargs.pop('extra_arguments', None) or []
 
@@ -247,10 +239,6 @@ class Client(object):
 
         self.config = self._get_config()
 
-    @staticmethod
-    def _validate_url(url):
-        return urllib.parse.urlparse(url).scheme in ['http', 'https']
-
     def _get_config(self):
         """
         Read and validate configuration data for installation.
@@ -271,27 +259,15 @@ class Client(object):
 
         # Get the raw config data
         data = ''
-        if self._validate_url(self.config_path):
-            try:
-                data = urllib.request.urlopen(self.config_path).read()
-            except urllib.error.URLError:
-                msg = (
-                    'The URL used to get the user config.yaml file did not '
-                    'work! Please make sure your config is available.'
-                )
-                self.log.critical(msg)
-                raise
-        elif self.config_path and not os.path.exists(self.config_path):
+        try:
+            data = urlopen(self.config_path).read()
+        except (ValueError, urllib.error.URLError):
             msg = (
-                'User supplied config {0} does not exist. Please '
-                'double-check your config path or use the default config '
-                'path.'.format(self.config_path)
+                'Could not read the config from {0}! Please make sure your '
+                'config is available.'.format(self.config_path)
             )
             self.log.critical(msg)
-            raise WatchmakerException(msg)
-        else:
-            with codecs.open(self.config_path, encoding="utf-8") as fh_:
-                data = fh_.read()
+            raise
 
         config_full = yaml.safe_load(data)
         try:

--- a/src/watchmaker/__init__.py
+++ b/src/watchmaker/__init__.py
@@ -15,11 +15,12 @@ import setuptools
 import yaml
 from six.moves import urllib
 
+import watchmaker.utils
+import watchmaker.utils.urllib
 from watchmaker import static
 from watchmaker.exceptions import WatchmakerException
 from watchmaker.managers.workers import (LinuxWorkersManager,
                                          WindowsWorkersManager)
-from watchmaker.utils.urllib import urlopen
 
 
 def _extract_version(package_name):
@@ -257,10 +258,13 @@ class Client(object):
         else:
             self.log.info('User supplied config being used.')
 
+        # Convert a local config path to a URI
+        self.config_path = watchmaker.utils.path_to_uri(self.config_path)
+
         # Get the raw config data
         data = ''
         try:
-            data = urlopen(self.config_path).read()
+            data = watchmaker.utils.urllib.urlopen(self.config_path).read()
         except (ValueError, urllib.error.URLError):
             msg = (
                 'Could not read the config from {0}! Please make sure your '

--- a/src/watchmaker/cli.py
+++ b/src/watchmaker/cli.py
@@ -47,11 +47,6 @@ LOG_LOCATIONS = {
                   'Comma-separated string of salt states to apply. A value of '
                   '\'None\' will not apply any salt states. A value of '
                   '\'Highstate\' will apply the salt highstate.'))
-@click.option('--s3-source', 's3_source', flag_value=True, default=None,
-              help=(
-                  'Use S3 utilities to retrieve content instead of http/s '
-                  'utilities. Boto3 must be installed, and boto3 credentials '
-                  'must be configured that allow access to the S3 bucket.'))
 @click.option('-A', '--admin-groups', default=None,
               help=(
                   'Set a salt grain that specifies the domain groups that '

--- a/src/watchmaker/managers/base.py
+++ b/src/watchmaker/managers/base.py
@@ -17,6 +17,7 @@ from six import add_metaclass
 from six.moves import urllib
 
 from watchmaker.exceptions import WatchmakerException
+from watchmaker.utils.urllib import urlopen
 
 
 class ManagerBase(object):
@@ -61,48 +62,11 @@ class ManagerBase(object):
         args = args
         kwargs = kwargs
 
-    def _import_boto3(self):
-        if self.boto3:
-            return
-
-        self.log.info("Dynamically importing boto3 ...")
-        try:
-            self.boto3 = __import__("boto3")
-            self.boto_client = __import__(
-                "botocore.client",
-                globals(),
-                locals(),
-                ["ClientError"],
-                0
-            )
-        except ImportError:
-            msg = 'Unable to import boto3 module.'
-            self.log.critical(msg)
-            raise
-
-    def _get_s3_file(self, url, bucket_name, key_name, destination):
-        self._import_boto3()
-
-        try:
-            s3_ = self.boto3.resource("s3")
-            s3_.meta.client.head_bucket(Bucket=bucket_name)
-            s3_.Object(bucket_name, key_name).download_file(destination)
-        except self.boto_client.ClientError:
-            msg = 'Bucket does not exist.  bucket = {0}.'.format(bucket_name)
-            self.log.critical(msg)
-            raise
-        except Exception:
-            msg = (
-                'Unable to download file from S3 bucket. url = {0}. '
-                'bucket = {1}. key = {2}. file = {3}.'
-                .format(url, bucket_name, key_name, destination)
-            )
-            self.log.critical(msg)
-            raise
-
-    def download_file(self, url, filename, sourceiss3bucket=False):
+    def retrieve_file(self, url, filename):
         """
-        Download a file from a web server or S3 bucket.
+        Retrieve a file from a provided URL.
+
+        Supports all :obj:`urllib.request` handlers, as well as S3 buckets.
 
         Args:
             url: (:obj:`str`)
@@ -110,77 +74,27 @@ class ManagerBase(object):
 
             filename: (:obj:`str`)
                 Path where the file will be saved.
-
-            sourceiss3bucket: (:obj:`bool`)
-                Switch to indicate that the download should use boto3 to
-                download the file from an S3 bucket.
-                (*Default*: ``False``)
         """
         self.log.debug('Downloading: %s', url)
         self.log.debug('Destination: %s', filename)
-        self.log.debug('S3: %s', sourceiss3bucket)
 
-        if sourceiss3bucket:
-            self._import_boto3()
-
-            bucket_name = url.split('/')[3]
-            key_name = '/'.join(url.split('/')[4:])
-
-            self.log.debug('Bucket Name: %s', bucket_name)
-            self.log.debug('key_name: %s', key_name)
-
-            try:
-                s3_ = self.boto3.resource('s3')
-                s3_.meta.client.head_bucket(Bucket=bucket_name)
-                s3_.Object(bucket_name, key_name).download_file(filename)
-            except (NameError, self.boto_client.ClientError):
-                self.log.error('NameError: %s', self.boto_client.ClientError)
-                try:
-                    bucket_name = url.split('/')[2].split('.')[0]
-                    key_name = '/'.join(url.split('/')[3:])
-                    s3_ = self.boto3.resource("s3")
-                    s3_.meta.client.head_bucket(Bucket=bucket_name)
-                    s3_.Object(bucket_name, key_name).download_file(filename)
-                except Exception:
-                    msg = (
-                        'Unable to download file from S3 bucket. url = {0}. '
-                        'bucket = {1}. key = {2}. file = {3}.'
-                        .format(url, bucket_name, key_name, filename)
-                    )
-                    self.log.critical(msg)
-                    raise
-            except Exception:
-                msg = (
-                    'Unable to download file from S3 bucket. url = {0}. '
-                    'bucket = {1}. key = {2}. file = {3}.'
-                    .format(url, bucket_name, key_name, filename)
-                )
-                self.log.critical(msg)
-                raise
-            self.log.info(
-                'Downloaded file from S3 bucket. url=%s. filename=%s',
+        try:
+            self.log.debug('Establishing connection to the host, %s', url)
+            response = urlopen(url)
+            self.log.debug('Opening the file handle, %s', filename)
+            with open(filename, 'wb') as outfile:
+                self.log.debug('Saving file to local filesystem...')
+                shutil.copyfileobj(response, outfile)
+        except (ValueError, urllib.error.URLError):
+            self.log.critical(
+                'Failed to retrieve the file. url = %s. filename = %s',
                 url, filename
             )
-        else:
-            try:
-                self.log.debug('Opening connection to web server, %s', url)
-                response = urllib.request.urlopen(url)
-                self.log.debug('Opening the file handle, %s', filename)
-                with open(filename, 'wb') as outfile:
-                    self.log.debug('Saving file to local filesystem...')
-                    shutil.copyfileobj(response, outfile)
-            except Exception:
-                msg = (
-                    'Unable to download file from web server. url = {0}. '
-                    'filename = {1}.'
-                    .format(url, filename)
-                )
-                self.log.critical(msg)
-                raise
-            self.log.info(
-                'Downloaded file from web server. url=%s. filename=%s',
-                url, filename
-            )
+            raise
+        self.log.info(
+            'Retrieved the file successfully. url=%s. filename=%s',
+            url, filename
+        )
 
     def create_working_dir(self, basedir, prefix):
         """

--- a/src/watchmaker/managers/base.py
+++ b/src/watchmaker/managers/base.py
@@ -16,8 +16,9 @@ import zipfile
 from six import add_metaclass
 from six.moves import urllib
 
+import watchmaker.utils
+import watchmaker.utils.urllib
 from watchmaker.exceptions import WatchmakerException
-from watchmaker.utils.urllib import urlopen
 
 
 class ManagerBase(object):
@@ -75,12 +76,14 @@ class ManagerBase(object):
             filename: (:obj:`str`)
                 Path where the file will be saved.
         """
+        # Convert a local path to a URI
+        url = watchmaker.utils.path_to_uri(url)
         self.log.debug('Downloading: %s', url)
         self.log.debug('Destination: %s', filename)
 
         try:
             self.log.debug('Establishing connection to the host, %s', url)
-            response = urlopen(url)
+            response = watchmaker.utils.urllib.urlopen(url)
             self.log.debug('Opening the file handle, %s', filename)
             with open(filename, 'wb') as outfile:
                 self.log.debug('Saving file to local filesystem...')

--- a/src/watchmaker/managers/base.py
+++ b/src/watchmaker/managers/base.py
@@ -14,11 +14,10 @@ import tempfile
 import zipfile
 
 from six import add_metaclass
-from six.moves import urllib
 
 import watchmaker.utils
-import watchmaker.utils.urllib
 from watchmaker.exceptions import WatchmakerException
+from watchmaker.utils import urllib
 
 
 class ManagerBase(object):
@@ -83,7 +82,7 @@ class ManagerBase(object):
 
         try:
             self.log.debug('Establishing connection to the host, %s', url)
-            response = watchmaker.utils.urllib.urlopen(url)
+            response = urllib.request.urlopen(url)
             self.log.debug('Opening the file handle, %s', filename)
             with open(filename, 'wb') as outfile:
                 self.log.debug('Saving file to local filesystem...')

--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -7,7 +7,6 @@ all:
       ou_path: None
       salt_content: https://s3.amazonaws.com/watchmaker/salt-content.zip
       salt_states: Highstate
-      s3_source: False
       user_formulas:
         # To add extra formulas, specify them as a map of
         #    <formula_name>: <archive_url>

--- a/src/watchmaker/utils/__init__.py
+++ b/src/watchmaker/utils/__init__.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import os
 
-from six.moves.urllib import parse, request
+from six.moves.urllib import parse, request  # pylint: disable=import-error
 
 
 def path_to_uri(filepath):

--- a/src/watchmaker/utils/__init__.py
+++ b/src/watchmaker/utils/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+"""Loads helper utility modules."""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals, with_statement)

--- a/src/watchmaker/utils/__init__.py
+++ b/src/watchmaker/utils/__init__.py
@@ -1,4 +1,29 @@
 # -*- coding: utf-8 -*-
-"""Loads helper utility modules."""
+"""Loads helper utility modules and functions."""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals, with_statement)
+
+import os
+
+from six.moves.urllib import parse, request
+
+
+def path_to_uri(filepath):
+    """Convert a file path to a URI compatible with urllib."""
+    parts = parse.urlparse(filepath)
+
+    # Handle case where path does not contain a scheme
+    # i.e. '/abspath/foo' or 'relpath/foo'
+    # Do not test `if parts.scheme` because of how urlparse handles Windows
+    # file paths -- i.e. 'C:\\foo' => scheme = 'c' :(
+    scheme = parts.scheme if '://' in filepath else 'file'
+
+    if scheme != 'file':
+        # Return non-file paths unchanged
+        return filepath
+
+    # Expand relative file paths and convert them to url-style
+    path = request.pathname2url(os.path.abspath(os.path.expanduser(
+        ''.join([x for x in [parts.netloc, parts.path] if x]))))
+
+    return parse.urlunparse((scheme, '', path, '', '', ''))

--- a/src/watchmaker/utils/__init__.py
+++ b/src/watchmaker/utils/__init__.py
@@ -5,7 +5,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import os
 
-from six.moves.urllib import parse, request  # pylint: disable=import-error
+from watchmaker.utils.urllib import parse, request
 
 
 def path_to_uri(filepath):

--- a/src/watchmaker/utils/urllib/__init__.py
+++ b/src/watchmaker/utils/urllib/__init__.py
@@ -1,91 +1,12 @@
 # -*- coding: utf-8 -*-
-"""Extends urllib with additional handlers."""
+"""Exposes urllib imports with additional request handlers."""
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals, with_statement)
 
-import io
-from email import message_from_string
+# pylint: disable=import-error
+from six.moves.urllib import error, parse, request  # noqa: F401
 
-from six.moves import urllib
-
-HAS_BOTO3 = False
-try:
-    import boto3
-    HAS_BOTO3 = True
-except ImportError:
-    pass
-
-
-class BufferedIOS3Key(io.BufferedIOBase):
-    """Add a read method to S3 key object."""
-
-    def __init__(self, key, *args, **kwargs):
-        super(BufferedIOS3Key, self).__init__(*args, **kwargs)
-        self.read = key.get()['Body'].read
-
-
-class S3Handler(urllib.request.BaseHandler):
-    """Define urllib handler for S3 objects."""
-
-    def s3_open(self, req):
-        """Open S3 objects."""
-        # Credit: <https://github.com/ActiveState/code/tree/master/recipes/Python/578957_Urllib_handler_AmazS3>  # noqa: E501, pylint: disable=line-too-long
-
-        # The implementation was inspired mainly by the code behind
-        # urllib.request.FileHandler.file_open().
-
-        try:
-            # py3 urllib
-            selector = req.selector
-        except AttributeError:
-            # py2 urllib2
-            selector = req.get_selector()
-
-        bucket_name = req.host
-        key_name = selector[1:]
-
-        if not bucket_name or not key_name:
-            raise urllib.error.URLError(
-                'url must be in the format s3://<bucket>/<key>'
-            )
-
-        try:
-            s3_conn = self.s3_conn
-        except AttributeError:
-            # pylint: disable=attribute-defined-outside-init
-            s3_conn = self.s3_conn = boto3.resource("s3")
-
-        key = s3_conn.Object(bucket_name=bucket_name, key=key_name)
-
-        origurl = 's3://{}/{}'.format(bucket_name, key_name)
-
-        if key is None:
-            raise urllib.error.URLError('no such resource: {}'.format(origurl))
-
-        headers = [
-            ('Content-type', key.content_type),
-            ('Content-encoding', key.content_encoding),
-            ('Content-language', key.content_language),
-            ('Content-length', key.content_length),
-            ('Etag', key.e_tag),
-            ('Last-modified', key.last_modified),
-        ]
-
-        headers = message_from_string(
-            '\n'.join(
-                '{0}: {1}'.format(header, value) for header, value in headers
-                if value is not None
-            )
-        )
-
-        return urllib.response.addinfourl(
-            BufferedIOS3Key(key), headers, origurl
-        )
-
+from watchmaker.utils.urllib.request_handlers import HAS_BOTO3, S3Handler
 
 if HAS_BOTO3:
-    # pylint: disable=invalid-name
-    s3_opener = urllib.request.build_opener(S3Handler)
-    urllib.request.install_opener(s3_opener)
-
-urlopen = urllib.request.urlopen  # pylint: disable=invalid-name
+    request.install_opener(request.build_opener(S3Handler))

--- a/src/watchmaker/utils/urllib/__init__.py
+++ b/src/watchmaker/utils/urllib/__init__.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""Extends urllib with additional handlers."""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals, with_statement)
+
+import io
+from email import message_from_string
+
+from six.moves import urllib
+
+HAS_BOTO3 = False
+try:
+    import boto3
+    HAS_BOTO3 = True
+except ImportError:
+    pass
+
+
+class BufferedIOS3Key(io.BufferedIOBase):
+    """Add a read method to S3 key object."""
+
+    def __init__(self, key):
+        self.read = key.get()['Body'].read
+
+
+class S3Handler(urllib.request.BaseHandler):
+    """Define urllib handler for S3 objects."""
+
+    def s3_open(self, req):
+        """Open S3 objects."""
+        # Credit: <https://github.com/ActiveState/code/tree/master/recipes/Python/578957_Urllib_handler_AmazS3>  # noqa: E501
+
+        # The implementation was inspired mainly by the code behind
+        # urllib.request.FileHandler.file_open().
+
+        try:
+            # py3 urllib
+            selector = req.selector
+        except AttributeError:
+            # py2 urllib2
+            selector = req.get_selector()
+
+        bucket_name = req.host
+        key_name = selector[1:]
+
+        if not bucket_name or not key_name:
+            raise urllib.error.URLError(
+                'url must be in the format s3://<bucket>/<key>'
+            )
+
+        try:
+            s3 = self._s3
+        except AttributeError:
+            s3 = self._s3 = boto3.resource("s3")
+
+        key = s3.Object(bucket_name=bucket_name, key=key_name)
+
+        origurl = 's3://{}/{}'.format(bucket_name, key_name)
+
+        if key is None:
+            raise urllib.error.URLError('no such resource: {}'.format(origurl))
+
+        headers = [
+            ('Content-type', key.content_type),
+            ('Content-encoding', key.content_encoding),
+            ('Content-language', key.content_language),
+            ('Content-length', key.content_length),
+            ('Etag', key.e_tag),
+            ('Last-modified', key.last_modified),
+        ]
+
+        headers = message_from_string(
+            '\n'.join(
+                '{0}: {1}'.format(header, value) for header, value in headers
+                if value is not None
+            )
+        )
+
+        return urllib.response.addinfourl(
+            BufferedIOS3Key(key), headers, origurl
+        )
+
+
+if HAS_BOTO3:
+    s3_opener = urllib.request.build_opener(S3Handler)
+    urllib.request.install_opener(s3_opener)
+
+urlopen = urllib.request.urlopen

--- a/src/watchmaker/utils/urllib/request_handlers.py
+++ b/src/watchmaker/utils/urllib/request_handlers.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""Extends urllib with additional handlers."""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals, with_statement)
+
+import io
+from email import message_from_string
+
+from six.moves import urllib
+
+HAS_BOTO3 = False
+try:
+    import boto3
+    HAS_BOTO3 = True
+except ImportError:
+    pass
+
+
+class BufferedIOS3Key(io.BufferedIOBase):
+    """Add a read method to S3 key object."""
+
+    def __init__(self, key, *args, **kwargs):
+        super(BufferedIOS3Key, self).__init__(*args, **kwargs)
+        self.read = key.get()['Body'].read
+
+
+class S3Handler(urllib.request.BaseHandler):
+    """Define urllib handler for S3 objects."""
+
+    def s3_open(self, req):
+        """Open S3 objects."""
+        # Credit: <https://github.com/ActiveState/code/tree/master/recipes/Python/578957_Urllib_handler_AmazS3>  # noqa: E501, pylint: disable=line-too-long
+
+        # The implementation was inspired mainly by the code behind
+        # urllib.request.FileHandler.file_open().
+
+        try:
+            # py3 urllib
+            selector = req.selector
+        except AttributeError:
+            # py2 urllib2
+            selector = req.get_selector()
+
+        bucket_name = req.host
+        key_name = selector[1:]
+
+        if not bucket_name or not key_name:
+            raise urllib.error.URLError(
+                'url must be in the format s3://<bucket>/<key>'
+            )
+
+        try:
+            s3_conn = self.s3_conn
+        except AttributeError:
+            # pylint: disable=attribute-defined-outside-init
+            s3_conn = self.s3_conn = boto3.resource("s3")
+
+        key = s3_conn.Object(bucket_name=bucket_name, key=key_name)
+
+        origurl = 's3://{0}/{1}'.format(bucket_name, key_name)
+
+        if key is None:
+            raise urllib.error.URLError(
+                'no such resource: {0}'.format(origurl)
+            )
+
+        headers = [
+            ('Content-type', key.content_type),
+            ('Content-encoding', key.content_encoding),
+            ('Content-language', key.content_language),
+            ('Content-length', key.content_length),
+            ('Etag', key.e_tag),
+            ('Last-modified', key.last_modified),
+        ]
+
+        headers = message_from_string(
+            '\n'.join(
+                '{0}: {1}'.format(header, value) for header, value in headers
+                if value is not None
+            )
+        )
+
+        return urllib.response.addinfourl(
+            BufferedIOS3Key(key), headers, origurl
+        )

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -27,13 +27,6 @@ class SaltBase(ManagerBase):
             log directory.
             (*Default*: ``''``)
 
-        s3_source: (:obj:`bool`)
-            Use S3 utilities to download salt content and user formulas from
-            an S3 bucket. If ``True``, you must also install ``boto3`` and
-            ``botocore``. Those dependencies will not be installed by
-            Watchmaker.
-            (*Default*: ``False``)
-
         salt_content: (:obj:`str`)
             URL to a salt content archive (zip file) that will be uncompressed
             in the watchmaker salt "srv" directory. This typically is used to
@@ -96,7 +89,6 @@ class SaltBase(ManagerBase):
         self.user_formulas = kwargs.pop('user_formulas', None) or {}
         self.computer_name = kwargs.pop('computer_name', None) or ''
         self.ent_env = kwargs.pop('environment', None) or ''
-        self.s3_source = kwargs.pop('s3_source', None) or False
         self.salt_debug_log = kwargs.pop('salt_debug_log', None) or ''
         self.salt_content = kwargs.pop('salt_content', None) or ''
         self.ou_path = kwargs.pop('ou_path', None) or ''
@@ -189,7 +181,7 @@ class SaltBase(ManagerBase):
             file_loc = os.sep.join((self.working_dir, filename))
 
             # Download the formula
-            self.download_file(formula_url, file_loc)
+            self.retrieve_file(formula_url, file_loc)
 
             # Extract the formula
             formula_working_dir = self.create_working_dir(
@@ -230,11 +222,7 @@ class SaltBase(ManagerBase):
                 self.working_dir,
                 salt_content_filename
             ))
-            self.download_file(
-                self.salt_content,
-                salt_content_file,
-                self.s3_source
-            )
+            self.retrieve_file(self.salt_content, salt_content_file)
             self.extract_contents(
                 filepath=salt_content_file,
                 to_directory=extract_dir
@@ -582,10 +570,7 @@ class SaltLinux(SaltBase, LinuxManager):
                 self.working_dir,
                 self.bootstrap_source.split('/')[-1]
             ))
-            self.download_file(
-                self.bootstrap_source,
-                salt_bootstrap_filename
-            )
+            self.retrieve_file(self.bootstrap_source, salt_bootstrap_filename)
             bootstrap_cmd = [
                 'sh',
                 salt_bootstrap_filename,
@@ -721,11 +706,7 @@ class SaltWindows(SaltBase, WindowsManager):
         installer_name = os.sep.join(
             (self.working_dir, self.installer_url.split('/')[-1])
         )
-        self.download_file(
-            self.installer_url,
-            installer_name,
-            self.s3_source
-        )
+        self.retrieve_file(self.installer_url, installer_name)
         install_cmd = [installer_name, '/S']
         self.call_process(install_cmd)
 

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -146,7 +146,7 @@ class Yum(LinuxManager):
                 url = repo['url']
                 repofile = '/etc/yum.repos.d/{0}'.format(
                     url.split('/')[-1])
-                self.download_file(url, repofile)
+                self.retrieve_file(url, repofile)
             else:
                 self.log.debug(
                     'Skipped repo because it is not valid for this system: '


### PR DESCRIPTION
This patch uses urllib's built-in functionality to retrieve files from remote and local sources. Syntax for any handler supported by [urllib.request](https://docs.python.org/3/library/urllib.request.html) will work.

The prior custom S3 file download methods are replaced by a custom urllib S3Handler. If boto3 is available, the handler is installed as a urllib opener so it can be used through urlopen. As a result, the `s3_source` argument is no longer needed and has been removed.

Note: Additional handlers (e.g. Azure) can be supported similarly, just by adding a class with an appropriate method to `watchmaker.utils.urllib`, and installing the opener.

Also included is a helper function that resolves local file paths to the URI syntax expected by the urllib handlers. Since urllib requires the absolute path, to support relative paths passed by the user, this helper also qualifies relative=>absolute paths. For example:

* `/foo/bar/baz.yaml` => `file:///foo/bar/baz/.yaml`
* `baz.yaml` => `file:///foo/bar/baz/.yaml`
* `file://baz.yaml` => `file:///foo/bar/baz/.yaml`
    * Note: lack of a third-slash after `file://` indicates a relative path, which needs to be qualified
* `C:\foo\bar\baz.yaml` => `file:///C:/foo/bar/baz/.yaml`

Example usages:

* `https://host/path/to/config.yaml`
* `s3://bucket/key/config.yaml`
* `file:///abspath/to/config.yaml`
* `file://C:/abspath/to/config.yaml`
* `file://relpath/to/config.yaml`
* `relpath/to/config.yaml`
* `relpath\to\config.yaml`
* `/abspath/to/config.yaml`
* `C:\abspath\to\config.yaml`

Closes #79
Closes #143
Closes #501