### PR TITLE
Uses `python -m pip install --upgrade pip` to install pip

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ specify something like this for EC2 userdata:
     yum -y install git
 
     # Upgrade pip and setuptools
-    pip install --index-url="$PYPI_URL" --upgrade pip setuptools
+    python -m pip install --index-url="$PYPI_URL" --upgrade pip setuptools
 
     # Clone watchmaker
     git clone "$GIT_REPO" --branch "$GIT_BRANCH" --recursive
@@ -196,7 +196,7 @@ specify something like this for EC2 userdata:
         -Verbose -ErrorAction Stop
 
     # Upgrade pip and setuptools
-    pip install --index-url="$PypiUrl" --upgrade pip setuptools
+    python -m pip install --index-url="$PypiUrl" --upgrade pip setuptools
 
     # Clone watchmaker
     git clone "$GitRepo" --branch "$GitBranch" --recursive

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -89,7 +89,8 @@ PYPI_URL=https://pypi.org/simple
 curl "$PIP_URL" | python - --index-url="$PYPI_URL" wheel==0.29.0
 
 # Install watchmaker
-pip install --index-url="$PYPI_URL" --upgrade pip setuptools watchmaker
+python -m pip install --index-url="$PYPI_URL" --upgrade pip setuptools
+pip install --index-url="$PYPI_URL" --upgrade watchmaker
 
 # Run watchmaker
 watchmaker --log-level debug --log-dir=/var/log/watchmaker
@@ -109,7 +110,8 @@ runcmd:
     curl "$PIP_URL" | python - --index-url="$PYPI_URL" wheel==0.29.0
 
     # Install watchmaker
-    pip install --index-url="$PYPI_URL" --upgrade pip setuptools watchmaker
+    python -m pip install --index-url="$PYPI_URL" --upgrade pip setuptools
+    pip install --index-url="$PYPI_URL" --upgrade watchmaker
 
     # Run watchmaker
     watchmaker --log-level debug --log-dir=/var/log/watchmaker
@@ -135,7 +137,8 @@ $BootstrapFile = "${Env:Temp}\$(${BootstrapUrl}.split('/')[-1])"
 & "$BootstrapFile" -PythonUrl "$PythonUrl" -Verbose -ErrorAction Stop
 
 # Install watchmaker
-pip install --index-url="$PypiUrl" --upgrade pip setuptools watchmaker
+python -m pip install --index-url="$PypiUrl" --upgrade pip setuptools
+pip install --index-url="$PypiUrl" --upgrade watchmaker
 
 # Run watchmaker
 watchmaker --log-level debug --log-dir=C:\Watchmaker\Logs


### PR DESCRIPTION
Avoids permissions errors on Windows when upgrading pip because
Windows does not allow a running executable to be removed.