### PR TITLE
Patch to address pypi version limitations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,9 +34,9 @@ before_script:
   - |
     if [ "$TRAVIS_BRANCH" = "develop" ]; then
       # whether setup.cfg version has "dev" or not, it is added but not duplicated
-      sha=${TRAVIS_COMMIT:0:7} 
-      sed -i -E "s/^(version = )([0-9]+\.[0-9]+\.[0-9]+).*$/\1\2.dev$sha/" setup.cfg
-    fi  
+      ver=$(git show -s --format=%cd --date=format:'%Y%m%d%H%M%S')
+      sed -i -E "s/^(version = )([0-9]+\.[0-9]+\.[0-9]+).*$/\1\2.dev$ver/" setup.cfg
+    fi
 after_failure:
   - more .tox/log/* | cat
   - more .tox/*/log/* | cat

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -68,8 +68,8 @@ before_deploy:
   - ps: >-  
       if($env:APPVEYOR_REPO_BRANCH -eq "develop") {
         # whether setup.cfg version has "dev" or not, it is added but not duplicated
-        $sha = ($env:APPVEYOR_REPO_COMMIT).Substring(0,7)
-        (Get-Content setup.cfg) -replace '^(version = )(\d+\.\d+\.\d+).*$', ('$1$2.dev' + $sha) | Set-Content setup.cfg
+        $ver = (git show -s --format=%cd --date=format:'%Y%m%d%H%M%S')
+        (Get-Content setup.cfg) -replace '^(version = )(\d+\.\d+\.\d+).*$', ('$1$2.dev' + $ver) | Set-Content setup.cfg
       }
   - pip install --editable .      # install wam, as needed by GB
   # create standalone application


### PR DESCRIPTION
Patch related to #618, #619, #621.
Instead of using build IDs from AppVeyor and Travis CI, this uses time of the commit, tacked onto dev.