### PR TITLE
Address changes and upgrade to pylint 2

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -74,7 +74,8 @@ disable=
     too-few-public-methods,
     too-many-branches,
     too-many-instance-attributes,
-    too-many-statements
+    too-many-statements,
+    useless-object-inheritance
 
 [REPORTS]
 

--- a/requirements/check.txt
+++ b/requirements/check.txt
@@ -10,5 +10,5 @@ m2r==0.1.15
 pep8-naming==0.7.0
 pydocstyle==2.1.1
 pygments==2.2.0
-pylint==1.9.2
+pylint==2.0.0
 readme-renderer==21.0

--- a/src/watchmaker/managers/base.py
+++ b/src/watchmaker/managers/base.py
@@ -369,16 +369,16 @@ class WorkersManagerBase(object):
 
     @abc.abstractmethod
     def _worker_execution(self):
-        return
+        pass
 
     @abc.abstractmethod
     def _worker_validation(self):
-        return
+        pass
 
     @abc.abstractmethod
     def worker_cadence(self):  # noqa: D102
-        return
+        pass
 
     @abc.abstractmethod
     def cleanup(self):  # noqa: D102
-        return
+        pass


### PR DESCRIPTION
- This can supersede #644.
- PyLint 2 makes an effort to make a break with Python 2. By default, they now suggest that classes not inherit explicitly from object. Since we are still maintaining Python 2 compatibility, we can ignore the R0205 (useless-object-inheritance) messages.
- Abstract methods can use `pass` instead of `return` to avoid the R1711 (useless-return) message.