### PR TITLE
Restricts pyyaml version to support python 3.4 (for el6)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.16.6
+current_version = 0.16.7
 commit = False
 tag = False
 tag_name = {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+### 0.16.7
+
+**Commit Delta**: [Change from 0.16.6 release](https://github.com/plus3it/watchmaker/compare/0.16.6...0.16.7)
+
+**Released**: 2020.01.06
+
+**Summary**:
+
+*   Pins `PyYAML` dependency when running on Python 3.4 or earlier
+
 ### 0.16.6
 
 **Commit Delta**: [Change from 0.16.5 release](https://github.com/plus3it/watchmaker/compare/0.16.5...0.16.6)

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,8 @@ install_requires =
     futures;python_version<"3"
     six
     pypiwin32;platform_system=="Windows"
-    PyYAML;python_version>="2.7"
+    PyYAML;python_version>="3.5"
+    PyYAML<=5.2;python_version<"3.5"
     PyYAML<4;python_version<"2.7"
     wheel<=0.29.0;python_version<"2.7"
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 [metadata]
 name = watchmaker
 description = Applied Configuration Management
-version = 0.16.6
+version = 0.16.7
 author = Plus3IT Maintainers of Watchmaker
 author_email = projects@plus3it.com
 url = https://github.com/plus3it/watchmaker


### PR DESCRIPTION
This will be a patch release, to fix installs on EL6 using python 3.4...