### PR TITLE
Uses salt 2018.3.4 in the default config

### DIFF
--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -26,16 +26,16 @@ linux:
             - redhat
             - centos
           el_version: 6
-          url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/2018.3.3/salt-reposync-el6.repo
+          url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/2018.3.4/salt-reposync-el6.repo
         - dist: amazon
           el_version: 6
-          url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/2018.3.3/salt-reposync-amzn.repo
+          url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/2018.3.4/salt-reposync-amzn.repo
         #SaltEL7:
         - dist:
             - redhat
             - centos
           el_version: 7
-          url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/2018.3.3/salt-reposync-el7.repo
+          url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/2018.3.4/salt-reposync-el7.repo
   - salt:
       salt_debug_log: None
       install_method: yum
@@ -46,4 +46,4 @@ linux:
 windows:
   - salt:
       salt_debug_log: None
-      installer_url: https://watchmaker.cloudarmor.io/repo/saltstack/salt/windows/Salt-Minion-2018.3.3-Py2-AMD64-Setup.exe
+      installer_url: https://watchmaker.cloudarmor.io/repo/saltstack/salt/windows/Salt-Minion-2018.3.4-Py2-AMD64-Setup.exe


### PR DESCRIPTION
Also, this is the first version that properly detects Windows Server 2019