### PR TITLE
Uses a custom default so `None` cli arguments are passed to workers

### DIFF
--- a/src/watchmaker/__init__.py
+++ b/src/watchmaker/__init__.py
@@ -167,6 +167,8 @@ class Arguments(dict):
 
     """
 
+    DEFAULT_VALUE = 'WAM_NONE'
+
     def __init__(
         self,
         config_path=None,
@@ -182,20 +184,20 @@ class Arguments(dict):
         self.no_reboot = no_reboot
         self.log_level = log_level
         self.admin_groups = watchmaker.utils.clean_none(
-            kwargs.pop('admin_groups', None))
+            kwargs.pop('admin_groups', None) or Arguments.DEFAULT_VALUE)
         self.admin_users = watchmaker.utils.clean_none(
-            kwargs.pop('admin_users', None))
+            kwargs.pop('admin_users', None) or Arguments.DEFAULT_VALUE)
         self.computer_name = watchmaker.utils.clean_none(
-            kwargs.pop('computer_name', None))
+            kwargs.pop('computer_name', None) or Arguments.DEFAULT_VALUE)
         self.environment = watchmaker.utils.clean_none(
-            kwargs.pop('environment', None))
+            kwargs.pop('environment', None) or Arguments.DEFAULT_VALUE)
         self.salt_states = watchmaker.utils.clean_none(
-            kwargs.pop('salt_states', None))
+            kwargs.pop('salt_states', None) or Arguments.DEFAULT_VALUE)
         self.ou_path = watchmaker.utils.clean_none(
-            kwargs.pop('ou_path', None))
+            kwargs.pop('ou_path', None) or Arguments.DEFAULT_VALUE)
         self.extra_arguments = [
-            watchmaker.utils.clean_none(val) for val in kwargs.pop(
-                'extra_arguments', None) or []
+            watchmaker.utils.clean_none(val or Arguments.DEFAULT_VALUE)
+            for val in kwargs.pop('extra_arguments', None) or []
         ]
 
     def __getattr__(self, attr):
@@ -258,7 +260,8 @@ class Client(object):
         ))
         # Set self.worker_args, removing `None` values from worker_args
         self.worker_args = dict(
-            (k, v) for k, v in worker_args.items() if v is not None
+            (k, v) for k, v in worker_args.items()
+            if v != Arguments.DEFAULT_VALUE
         )
 
         self.config = self._get_config()

--- a/tests/test_watchmaker.py
+++ b/tests/test_watchmaker.py
@@ -69,3 +69,16 @@ def test_none_arguments():
     assert not watchmaker_arguments.computer_name
     assert not watchmaker_arguments.salt_states
     assert not watchmaker_arguments.ou_path
+
+
+def test_argument_default_value():
+    """Ensure argument default value is `Arguments.DEFAULT_VALUE`."""
+    raw_arguments = {}
+    check_val = watchmaker.Arguments.DEFAULT_VALUE
+    watchmaker_arguments = watchmaker.Arguments(**dict(**raw_arguments))
+
+    assert watchmaker_arguments.admin_groups == check_val
+    assert watchmaker_arguments.admin_users == check_val
+    assert watchmaker_arguments.computer_name == check_val
+    assert watchmaker_arguments.salt_states == check_val
+    assert watchmaker_arguments.ou_path == check_val


### PR DESCRIPTION
Previously, `None` was filtered from the arguments passed to workers
as a way of differentiating between arguments that were passed on
the cli and those that simply had a `None` default value. This
worked when the worker had special handling for the string `'None'`
because that is how the cli would pass the string value along.

When the special handling for `None` was deprecated, the filtering
of `None` from cli args began removing the arg even if the user
specified the value.

In other words, `--salt-states none` would get converted properly
from `{'salt_states': 'none'}` to `{'salt_states': None}`, but then
the filter would remove the arg instead of passing it to the worker.

This patch changes the default for these worker args to a static
value, `Arguments.DEFAULT_VALUE`, and then filters that value
instead of `None`. This way users can pass `'None'`, the
Arguments() processing can change it to `None`, and it will still
get passed to the worker.