### PR TITLE
Removes winrepo.genrepo usage in Windows Salt worker

### DIFF
--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -957,8 +957,6 @@ class SaltWindows(SaltBase, WindowsPlatformManager):
 
         self.process_grains()
 
-        self.log.info('Generating winrepo cache file...')
-        self.run_salt('winrepo.genrepo')
         self.log.info('Refreshing package database...')
         self.run_salt('pkg.refresh_db')
 


### PR DESCRIPTION
Salt documentation indicates that using `winrepo.genrepo` to generate the meta database file for Windows packages is no longer necessary.  See [Windows Package Manager](https://docs.saltstack.com/en/2019.2/topics/windows/windows-package-manager.html#maintaining-windows-repo-definitions-in-git-repositories).