### PR TITLE
Attempts to opt-in to deploy v2 using travis-ci version restriction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+version: ~> 1.0
+
 dist: bionic
 language: python
 stages:
@@ -36,6 +38,7 @@ before_script:
       ver=$(git show -s --format=%cd --date=format:'%Y%m%d%H%M%S')
       sed -i -E "s/^(version = )([0-9]+\.[0-9]+\.[0-9]+).*$/\1\2.dev$ver/" setup.cfg
     fi
+  - grep "version = " setup.cfg
 after_failure:
   - more .tox/log/* | cat
   - more .tox/*/log/* | cat
@@ -110,7 +113,8 @@ jobs:
       if: type != pull_request AND (branch = develop OR tag is present)
       python: 2.7
       install: skip
-      script: echo "Deploying..."
+      script: skip
+      before_deploy: echo Deploying "$(grep 'version = ' setup.cfg)"
       deploy:
       - provider: pypi
         server: https://test.pypi.org/legacy/


### PR DESCRIPTION
Noticed that it seems travis-ci is clearing the modification to the version on the develop branch before the deploy to test pypi, which causes problems with pypi and duplicate files.

v1 of the deploy provider defaults to cleaning up the branch, and uses `skip_cleanup` to override. v2 defaults to skipping the cleanup, and uses `cleanup` to override. In the last pr, we switched from `skip_cleanup: true` to `cleanup: false`, but the cleanup still happened. So guessing that we're stuck on the v1 deploy provider, despite travis-ci saying the `cleanup` config is correct. 🤷‍♂️ 