### PR TITLE
Allows user to pass yaml/json strings to extra args on cli

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,7 +173,8 @@ Parameters supported by the Salt Worker:
 -   `salt_version` (_string_): (Linux-only) A git reference present in
     `git_repo`, such as a commit or a tag. If not specifid, the HEAD of the
     default branch will be used.
-    `installer_url` (_string_): (Windows-only) URL to the Salt Minion installer
+
+-   `installer_url` (_string_): (Windows-only) URL to the Salt Minion installer
     for Windows.
 
 ### yum worker (linux-only)

--- a/src/watchmaker/__init__.py
+++ b/src/watchmaker/__init__.py
@@ -261,7 +261,7 @@ class Client(object):
         ))
         # Set self.worker_args, removing `None` values from worker_args
         self.worker_args = dict(
-            (k, v) for k, v in worker_args.items()
+            (k, yaml.safe_load(v)) for k, v in worker_args.items()
             if v != Arguments.DEFAULT_VALUE
         )
 

--- a/tests/test_watchmaker.py
+++ b/tests/test_watchmaker.py
@@ -82,3 +82,83 @@ def test_argument_default_value():
     assert watchmaker_arguments.computer_name == check_val
     assert watchmaker_arguments.salt_states == check_val
     assert watchmaker_arguments.ou_path == check_val
+
+
+def test_extra_arguments_string():
+    """Test string in extra_arguments loads correctly."""
+    # setup
+    raw_arguments = {
+        "extra_arguments": [
+            '--foo',
+            'bar'
+        ]
+    }
+    check_val = {"foo": "bar"}
+
+    watchmaker_arguments = watchmaker.Arguments(**dict(**raw_arguments))
+
+    # test
+    watchmaker_client = watchmaker.Client(watchmaker_arguments)
+
+    # assertions
+    assert watchmaker_client.worker_args == check_val
+
+
+def test_extra_arguments_quoted_string():
+    """Test quoted string in extra_arguments loads correctly."""
+    # setup
+    raw_arguments = {
+        "extra_arguments": [
+            '--foo',
+            '"bar"'
+        ]
+    }
+    check_val = {"foo": "bar"}
+
+    watchmaker_arguments = watchmaker.Arguments(**dict(**raw_arguments))
+
+    # test
+    watchmaker_client = watchmaker.Client(watchmaker_arguments)
+
+    # assertions
+    assert watchmaker_client.worker_args == check_val
+
+
+def test_extra_arguments_list():
+    """Test list in extra_arguments loads correctly."""
+    # setup
+    raw_arguments = {
+        "extra_arguments": [
+            '--foo',
+            '["bar"]'
+        ]
+    }
+    check_val = {"foo": ["bar"]}
+
+    watchmaker_arguments = watchmaker.Arguments(**dict(**raw_arguments))
+
+    # test
+    watchmaker_client = watchmaker.Client(watchmaker_arguments)
+
+    # assertions
+    assert watchmaker_client.worker_args == check_val
+
+
+def test_extra_arguments_map():
+    """Test map in extra_arguments loads correctly."""
+    # setup
+    raw_arguments = {
+        "extra_arguments": [
+            '--user-formulas',
+            '{"foo-formula": "https://url"}'
+        ]
+    }
+    check_val = {"user_formulas": {"foo-formula": "https://url"}}
+
+    watchmaker_arguments = watchmaker.Arguments(**dict(**raw_arguments))
+
+    # test
+    watchmaker_client = watchmaker.Client(watchmaker_arguments)
+
+    # assertions
+    assert watchmaker_client.worker_args == check_val


### PR DESCRIPTION
Watchmaker passes all "extra" cli arguments to all workers, but previously,
users could only pass simple string arguments. Complex worker args could
be passed only in the config file.

This patch allows the user to pass them on the cli as json or yaml, and
deserializes them to python. E.g.

```
watchmaker --user-formulas '{"some-formula": "https:/url.zip"}'
```