### PR TITLE
Handles 'none' values passed on the cli properly

### DIFF
--- a/src/watchmaker/__init__.py
+++ b/src/watchmaker/__init__.py
@@ -287,7 +287,8 @@ class Client(object):
         try:
             # Set self.worker_args, removing `None` values from worker_args
             self.worker_args = dict(
-                (k, yaml.safe_load(v)) for k, v in worker_args.items()
+                (k, yaml.safe_load('null' if v is None else v))
+                for k, v in worker_args.items()
                 if v != Arguments.DEFAULT_VALUE
             )
         except yaml.YAMLError as exc:

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -129,7 +129,7 @@ class SaltBase(WorkerBase, PlatformManagerBase):
         self.pip_args = kwargs.pop('pip_args', None) or []
         self.pip_index = kwargs.pop('pip_index', None) or \
             'https://pypi.org/simple'
-        self.salt_states = kwargs.pop('salt_states', None) or ''
+        self.salt_states = kwargs.pop('salt_states', 'highstate') or ''
         self.exclude_states = kwargs.pop('exclude_states', None) or ''
 
         self.computer_name = watchmaker.utils.config_none_deprecate(
@@ -147,7 +147,7 @@ class SaltBase(WorkerBase, PlatformManagerBase):
         self.admin_users = watchmaker.utils.config_none_deprecate(
             self.admin_users, self.log)
         self.salt_states = watchmaker.utils.config_none_deprecate(
-            self.salt_states, self.log) or 'highstate'
+            self.salt_states, self.log)
 
         # Init attributes used by SaltBase, overridden by inheriting classes
         self.salt_working_dir = None

--- a/tests/test_saltworker.py
+++ b/tests/test_saltworker.py
@@ -79,6 +79,55 @@ def test_valid_environment(saltworker_client):
     assert saltworker_client.before_install() is None
 
 
+def test_salt_client_defaults():
+    """
+    Check SaltClient default values.
+
+    Args:
+        saltworker_client: (:obj:`src.workers.SaltBase`)
+
+    """
+    system_params = {}
+    salt_config = {}
+
+    saltworker_client = SaltBase(system_params, **salt_config)
+    assert saltworker_client.salt_states == 'highstate'
+
+
+def test_salt_client_none():
+    """
+    Check SaltClient handles None values properly.
+
+    Args:
+        saltworker_client: (:obj:`src.workers.SaltBase`)
+
+    """
+    system_params = {}
+    salt_config = {
+        'salt_states': None
+    }
+
+    saltworker_client = SaltBase(system_params, **salt_config)
+    assert saltworker_client.salt_states == ''
+
+
+def test_salt_client_explicit_value():
+    """
+    Check SaltClient handles explicit values properly.
+
+    Args:
+        saltworker_client: (:obj:`src.workers.SaltBase`)
+
+    """
+    system_params = {}
+    salt_config = {
+        'salt_states': 'foo'
+    }
+
+    saltworker_client = SaltBase(system_params, **salt_config)
+    assert saltworker_client.salt_states == 'foo'
+
+
 def test_process_states_highstate(
     saltworker_client,
     saltworker_base_salt_args,

--- a/tests/test_watchmaker.py
+++ b/tests/test_watchmaker.py
@@ -70,6 +70,11 @@ def test_none_arguments():
     assert watchmaker_arguments.salt_states is None
     assert watchmaker_arguments.ou_path is None
 
+    watchmaker_client = watchmaker.Client(watchmaker_arguments)
+
+    assert 'salt_states' in watchmaker_client.worker_args
+    assert watchmaker_client.worker_args['salt_states'] is None
+
 
 def test_argument_default_value():
     """Ensure argument default value is `Arguments.DEFAULT_VALUE`."""

--- a/tests/test_watchmaker.py
+++ b/tests/test_watchmaker.py
@@ -64,11 +64,11 @@ def test_none_arguments():
     }
     watchmaker_arguments = watchmaker.Arguments(**dict(**raw_arguments))
 
-    assert not watchmaker_arguments.admin_groups
-    assert not watchmaker_arguments.admin_users
-    assert not watchmaker_arguments.computer_name
-    assert not watchmaker_arguments.salt_states
-    assert not watchmaker_arguments.ou_path
+    assert watchmaker_arguments.admin_groups is None
+    assert watchmaker_arguments.admin_users is None
+    assert watchmaker_arguments.computer_name is None
+    assert watchmaker_arguments.salt_states is None
+    assert watchmaker_arguments.ou_path is None
 
 
 def test_argument_default_value():


### PR DESCRIPTION
Once upon a time, a `'none'` value on the cli was handled properly. It broke when we adding yaml parsing of cli values. Also, changing the `--salt-states` cli default to `None` broke how that setting was passed through to the salt worker, so it was always executing the salt worker default of `'highstate'`.

This patch adjusts the yaml parsing so the `None` value is parsed as `'null'` which again just returns `None`. This fixes the cli handling of `'none'` values.

This also adjusts the salt worker default for `salt_states` so `None` is honored when passed explicitly. When `salt_states` is not passed at all, the default value remains `'highstate'`.

Tests were updated or added to validate the correct behavior.