### PR TITLE
Disables --depth parameter when travis-ci fetches watchmaker code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ version: ~> 1.0
 
 dist: bionic
 language: python
+git:
+  depth: false
 stages:
   - test
   - deploy


### PR DESCRIPTION
This should resolve errors where the git tag cannot be determined due to insufficient git history, and so watchmaker cannot deploy to test pypi:

* https://app.travis-ci.com/github/plus3it/watchmaker/jobs/550376110#L255-L256
