### PR TITLE
Adds forescout-secure-connector as a submodule

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.24.3
+current_version = 0.25.0
 commit = False
 tag = False
 tag_name = {new_version}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
+[submodule "src/vendor/pypa/get-pip"]
+	path = src/vendor/pypa/get-pip
+	url = https://github.com/pypa/get-pip.git
 [submodule "src/watchmaker/static/salt/formulas/ash-linux-formula"]
 	path = src/watchmaker/static/salt/formulas/ash-linux-formula
 	url = https://github.com/plus3it/ash-linux-formula.git
@@ -46,6 +49,6 @@
 [submodule "src/watchmaker/static/salt/formulas/vault-auth-formula"]
 	path = src/watchmaker/static/salt/formulas/vault-auth-formula
 	url = https://github.com/plus3it/vault-auth-formula
-[submodule "src/vendor/pypa/get-pip"]
-	path = src/vendor/pypa/get-pip
-	url = https://github.com/pypa/get-pip.git
+[submodule "src/watchmaker/static/salt/formulas/forescout-secure-connector-formula"]
+	path = src/watchmaker/static/salt/formulas/forescout-secure-connector-formula
+	url = https://github.com/plus3it/forescout-secure-connector-formula.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.25.0
+
+**Commit Delta**: [Change from 0.24.3 release](https://github.com/plus3it/watchmaker/compare/0.24.3...0.25.0)
+
+**Released**: 2022.10.05
+
+**Summary**:
+
+*   [Alpha] Begins initial preparation to support running watchmaker on EL8 platforms
+*   forescout-secure-connector-formula
+    - First release that packages a formula for ForeScout Secure Connector
+
 ## 0.24.3
 
 **Commit Delta**: [Change from 0.24.2 release](https://github.com/plus3it/watchmaker/compare/0.24.2...0.24.3)
@@ -153,7 +165,7 @@
 
 *   Updates default config.yaml to use Salt 3003
 *   ash-linux-formula
-    - Adds ability to selectively skip extra EL7 STIG handlers 
+    - Adds ability to selectively skip extra EL7 STIG handlers
 *   nessus-agent-formula
     - (Linux) Updates nessus-agent to call install and configure states
 
@@ -173,7 +185,7 @@
 *   nessus-agent-formula
     - Separate agent install and configuration to support baked-in Nessus agent installations
 *   join-domain-formula
-    - (Windows) Add double-quotes to Members parameter in order for startup task state to work with Salt 3003 
+    - (Windows) Add double-quotes to Members parameter in order for startup task state to work with Salt 3003
 
 ## 0.21.8
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 [metadata]
 name = watchmaker
 description = Applied Configuration Management
-version = 0.24.3
+version = 0.25.0
 long_description = file: README.md, CHANGELOG.md
 long_description_content_type = text/markdown
 author = Plus3IT Maintainers of Watchmaker


### PR DESCRIPTION
Releases 0.25.0, with the new salt formula for the ForeScout Secure Connector.

Change comparison between the last release and main branch: https://github.com/plus3it/watchmaker/compare/0.24.3...main