### PR TITLE
Add Support for CentOS 8 Stream

### DIFF
--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -25,7 +25,6 @@ linux:
         #SaltEL6:
         - dist:
             - redhat
-            - rhel
             - centos
           el_version: 6
           url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/2019.2.8/salt-reposync-el6.repo
@@ -35,14 +34,12 @@ linux:
         #SaltEL7:
         - dist:
             - redhat
-            - rhel
             - centos
           el_version: 7
           url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/3004.2/salt-reposync-el7-python3.repo
         #SaltEL8:
         - dist:
             - redhat
-            - rhel
             - centos
           el_version: 8
           url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/3004.2/salt-reposync-el8-python3.repo

--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -25,6 +25,7 @@ linux:
         #SaltEL6:
         - dist:
             - redhat
+            - rhel
             - centos
           el_version: 6
           url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/2019.2.8/salt-reposync-el6.repo
@@ -34,12 +35,14 @@ linux:
         #SaltEL7:
         - dist:
             - redhat
+            - rhel
             - centos
           el_version: 7
           url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/3004.2/salt-reposync-el7-python3.repo
         #SaltEL8:
         - dist:
             - redhat
+            - rhel
             - centos
           el_version: 8
           url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/3004.2/salt-reposync-el8-python3.repo

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -3,7 +3,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals, with_statement)
 
-import io
 import re
 
 import distro

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -55,12 +55,12 @@ class Yum(WorkerBase, LinuxPlatformManager):
 
     def get_dist_info(self):
         """Validate the Linux distro and return info about the distribution."""
-        os_dist = dist.id()
+        dist = dist.id()
         version = dist.version()[0]
         el_version = None
 
         # Determine el_version
-        if os_dist == 'amazon':
+        if dist == 'amazon':
             el_version = self._get_amazon_el_version(version)
         else:
             el_version = dist.version()[0]
@@ -74,7 +74,7 @@ class Yum(WorkerBase, LinuxPlatformManager):
             raise WatchmakerError(msg)
 
         dist_info = {
-            'dist': os_dist,
+            'dist': dist,
             'el_version': el_version
         }
         self.log.debug('dist_info=%s', dist_info)

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -33,7 +33,7 @@ class Yum(WorkerBase, LinuxPlatformManager):
     DIST_PATTERN = re.compile(
         r"^({0})"
         "(?:[^0-9]+)"
-        r"([\d]+[.][\d]+)"
+        r"([\d]|[\d]+[.][\d])"
         "(?:.*)"
         .format('|'.join(SUPPORTED_DISTS))
     )

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -55,12 +55,12 @@ class Yum(WorkerBase, LinuxPlatformManager):
 
     def get_dist_info(self):
         """Validate the Linux distro and return info about the distribution."""
-        dist = dist.id()
+        os_dist = dist.id()
         version = dist.version()[0]
         el_version = None
 
         # Determine el_version
-        if dist == 'amazon':
+        if os_dist == 'amazon':
             el_version = self._get_amazon_el_version(version)
         else:
             el_version = dist.version()[0]
@@ -74,7 +74,7 @@ class Yum(WorkerBase, LinuxPlatformManager):
             raise WatchmakerError(msg)
 
         dist_info = {
-            'dist': dist,
+            'dist': os_dist,
             'el_version': el_version
         }
         self.log.debug('dist_info=%s', dist_info)

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -55,15 +55,15 @@ class Yum(WorkerBase, LinuxPlatformManager):
 
     def get_dist_info(self):
         """Validate the Linux distro and return info about the distribution."""
-        dist = dist.id()
-        version = dist.version()[0]
+        dist = distro.id()
+        version = distro.version()[0]
         el_version = None
 
         # Determine el_version
         if dist == 'amazon':
             el_version = self._get_amazon_el_version(version)
         else:
-            el_version = dist.version()[0]
+            el_version = distro.version()[0]
 
         if el_version is None:
             msg = (

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -45,17 +45,7 @@ class Yum(WorkerBase, LinuxPlatformManager):
 
     def get_dist_info(self):
         """Validate the Linux distro and return info about the distribution."""
-        # Error if 'dist' is not found in SUPPORTED_DISTS
-        try:
-            dist = self.SUPPORTED_DISTS[distro.id()]
-        except KeyError:
-            # Release not supported, exit with error
-            msg = (
-                'Unsupported OS distribution. OS must be one of: {0}'
-                .format(', '.join(self.SUPPORTED_DISTS.keys()))
-            )
-            self.log.critical(msg)
-            raise WatchmakerError(msg)
+        dist = self.get_mapped_dist_name()
         version = distro.version()[0]
         el_version = None
 
@@ -79,6 +69,20 @@ class Yum(WorkerBase, LinuxPlatformManager):
         }
         self.log.debug('dist_info=%s', dist_info)
         return dist_info
+
+    def get_mapped_dist_name(self):
+        """Return a normalized dist-name value."""
+        # Error if 'dist' is not found in SUPPORTED_DISTS
+        try:
+            return self.SUPPORTED_DISTS[distro.id()]
+        except KeyError:
+            # Release not supported, exit with error
+            msg = (
+                'Unsupported OS distribution. OS must be one of: {0}'
+                .format(', '.join(self.SUPPORTED_DISTS.keys()))
+            )
+            self.log.critical(msg)
+            raise WatchmakerError(msg)
 
     def _validate_config(self):
         """Validate the config is properly formed."""

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -3,8 +3,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals, with_statement)
 
-import re
-
 import distro
 import six
 
@@ -26,17 +24,6 @@ class Yum(WorkerBase, LinuxPlatformManager):
     """
 
     SUPPORTED_DISTS = ('amazon', 'centos', 'red hat', 'rhel')
-
-    # Pattern used to match against the first line of /etc/system-release. A
-    # match will contain two groups: the dist name (e.g. 'red hat' or 'amazon')
-    # and the dist version (e.g. '6.8' or '2016.09').
-    DIST_PATTERN = re.compile(
-        r"^({0})"
-        "(?:[^0-9]+)"
-        r"([\d]|[\d]+[.][\d])"
-        "(?:.*)"
-        .format('|'.join(SUPPORTED_DISTS))
-    )
 
     def __init__(self, *args, **kwargs):
         # Pop arguments used by Yum

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -23,7 +23,11 @@ class Yum(WorkerBase, LinuxPlatformManager):
 
     """
 
-    SUPPORTED_DISTS = ('amazon', 'centos', 'red hat', 'rhel')
+    SUPPORTED_DISTS = {
+        'amazon': 'amazon',
+        'centos': 'centos',
+        'rhel': 'redhat'
+    }
 
     def __init__(self, *args, **kwargs):
         # Pop arguments used by Yum
@@ -41,7 +45,17 @@ class Yum(WorkerBase, LinuxPlatformManager):
 
     def get_dist_info(self):
         """Validate the Linux distro and return info about the distribution."""
-        dist = distro.id()
+        # Error if 'dist' is not found in SUPPORTED_DISTS
+        try:
+            dist = self.SUPPORTED_DISTS[distro.id()]
+        except KeyError:
+            # Release not supported, exit with error
+            msg = (
+                'Unsupported OS distribution. OS must be one of: {0}'
+                .format(', '.join(self.SUPPORTED_DISTS.keys()))
+            )
+            self.log.critical(msg)
+            raise WatchmakerError(msg)
         version = distro.version()[0]
         el_version = None
 
@@ -55,16 +69,6 @@ class Yum(WorkerBase, LinuxPlatformManager):
             msg = (
                 'Unsupported OS version! dist = {0}, version = {1}.'
                 .format(dist, version)
-            )
-            self.log.critical(msg)
-            raise WatchmakerError(msg)
-
-        # Error if 'dist' is not found in SUPPORTED_DISTS
-        if dist not in self.SUPPORTED_DISTS:
-            # Release not supported, exit with error
-            msg = (
-                'Unsupported OS distribution. OS must be one of: {0}'
-                .format(', '.join(self.SUPPORTED_DISTS))
             )
             self.log.critical(msg)
             raise WatchmakerError(msg)

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -59,6 +59,16 @@ class Yum(WorkerBase, LinuxPlatformManager):
             self.log.critical(msg)
             raise WatchmakerError(msg)
 
+        # Error if 'dist' is not found in SUPPORTED_DISTS
+        if dist not in self.SUPPORTED_DISTS:
+            # Release not supported, exit with error
+            msg = (
+                'Unsupported OS distribution. OS must be one of: {0}'
+                .format(', '.join(self.SUPPORTED_DISTS))
+            )
+            self.log.critical(msg)
+            raise WatchmakerError(msg)
+
         dist_info = {
             'dist': dist,
             'el_version': el_version


### PR DESCRIPTION
Closes #2380 

- Validated against CentOS 8 Stream spel AMI `ami-0a6c4db379b52a51a`
- Validated against RHEL 8 spel (beta) AMI `ami-02e6c5efdce6956d`

**Note:** Due the changes in methodology used to identify target EC2s' distro-name, it will be necessary to update any free-standing `config.yaml` files to include `rhel` in the current `redhat` and `centos` config-map (see 480257e in this PR). The `redhat` map-member is preserved for backwards-compatibility