### PR TITLE
Add Support for Oracle Linux 8

### DIFF
--- a/src/watchmaker/static/config.yaml
+++ b/src/watchmaker/static/config.yaml
@@ -39,8 +39,11 @@ linux:
           url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/3004.2/salt-reposync-el7-python3.repo
         #SaltEL8:
         - dist:
-            - redhat
+            - almalinux
             - centos
+            - oracle
+            - redhat
+            - rocky
           el_version: 8
           url: https://watchmaker.cloudarmor.io/yum.defs/saltstack/salt/3004.2/salt-reposync-el8-python3.repo
   - salt:

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -24,9 +24,12 @@ class Yum(WorkerBase, LinuxPlatformManager):
     """
 
     SUPPORTED_DISTS = {
+        'almalinux': 'almalinux',
         'amazon': 'amazon',
         'centos': 'centos',
-        'rhel': 'redhat'
+        'oracle': 'oracle',
+        'rhel': 'redhat',
+        'rocky': 'rocky'
     }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
closes #2419 

While we're here, add selectors for `almalinux` and `rocky`