### PR TITLE
Replaces use of `__file__` and `__path__` with importlib metadata and resources

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "src/vendor/pypa/get-pip"]
-	path = src/vendor/pypa/get-pip
+	path = src/watchmaker/_vendor/pypa/get-pip
 	url = https://github.com/pypa/get-pip.git
 [submodule "src/watchmaker/static/salt/formulas/ash-linux-formula"]
 	path = src/watchmaker/static/salt/formulas/ash-linux-formula

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
   pool:
     vmImage: 'windows-2019'
   variables:
-    py: "3.7"
+    py: "3.8"
     architecture: "x64"
     venv: $(System.DefaultWorkingDirectory)\venv
     artifactDirFull: $(System.DefaultWorkingDirectory)\$(artifactDir)

--- a/ci/build.cmd
+++ b/ci/build.cmd
@@ -5,12 +5,18 @@ python --version
 python -m pip --version
 echo "-----------------------------------------------------------------------"
 
+; Remove when addressed: https://github.com/plus3it/gravitybee/issues/486
+git rm pyproject.toml
+
 python -m pip install -r requirements/build.txt
 python -m pip install --editable .
 python -m pip list
 
-# creates standalone
+; creates standalone
 gravitybee --src-dir src --sha file --with-latest --extra-data static --extra-data _vendor/pypa/get-pip/public/2.7 --extra-pkgs boto3 --extra-modules boto3
+
+git restore --staged pyproject.toml
+git restore pyproject.toml
 
 call .gravitybee/gravitybee-environs.bat
 %GB_ENV_GEN_FILE_W_PATH% --version

--- a/ci/build.cmd
+++ b/ci/build.cmd
@@ -10,7 +10,7 @@ python -m pip install --editable .
 python -m pip list
 
 # creates standalone
-gravitybee --src-dir src --sha file --with-latest --extra-data static --extra-data ../vendor/pypa/get-pip/public/2.7 --extra-pkgs boto3 --extra-modules boto3
+gravitybee --src-dir src --sha file --with-latest --extra-data static --extra-data _vendor/pypa/get-pip/public/2.7 --extra-pkgs boto3 --extra-modules boto3
 
 call .gravitybee/gravitybee-environs.bat
 %GB_ENV_GEN_FILE_W_PATH% --version

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -18,7 +18,7 @@ python -m pip install --editable .
 python -m pip list
 
 # creates standalone
-gravitybee --src-dir src --sha file --with-latest --extra-data static --extra-data ../vendor/pypa/get-pip/public/2.7 --extra-pkgs boto3 --extra-modules boto3
+gravitybee --src-dir src --sha file --with-latest --extra-data static --extra-data _vendor/pypa/get-pip/public/2.7 --extra-pkgs boto3 --extra-modules boto3
 
 source .gravitybee/gravitybee-environs.sh
 eval "$GB_ENV_GEN_FILE_W_PATH" --version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools", "wheel"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,8 @@ install_requires =
     PyYAML<=5.2;python_version<="2.7"
     compatibleversion>=0.1.2
     oschmod>=0.1.3
+package_dir =
+    = src
 packages = find:
 include_package_data = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -74,7 +74,7 @@ exclude =
     dist,
     htmlcov,
     */static/salt/formulas/*
-    */vendor/pypa/*
+    */_vendor/*
 ignore = FI15,FI16,FI17,FI18,FI5,D107,W503,W504
 
 [tool:pytest]

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,8 @@ install_requires =
     defusedxml;platform_system=="Windows"
     distro;python_version>="3.6"
     distro<=1.6.0;python_version<="2.7"
+    importlib_metadata
+    importlib_resources
     futures;python_version<"3"
     six
     pywin32;platform_system=="Windows"

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,4 @@ from __future__ import (absolute_import, division, print_function,
 
 from setuptools import setup
 
-setup(
-    package_dir={'': str('src')}
-)
+setup()

--- a/src/watchmaker/__init__.py
+++ b/src/watchmaker/__init__.py
@@ -10,9 +10,8 @@ import platform
 import re
 import subprocess
 
+import importlib_metadata
 import oschmod
-import pkg_resources
-import setuptools
 import yaml
 
 import watchmaker.utils
@@ -25,16 +24,7 @@ from watchmaker.status import Status
 
 
 def _extract_version(package_name):
-    try:
-        return pkg_resources.get_distribution(package_name).version
-    except pkg_resources.DistributionNotFound:
-        _conf = setuptools.config.read_configuration(
-            os.path.join(
-                os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-                "setup.cfg"
-            )
-        )
-        return _conf["metadata"]["version"]
+    return importlib_metadata.version(package_name)
 
 
 def _version_info(app_name, version):

--- a/src/watchmaker/_vendor/__init__.py
+++ b/src/watchmaker/_vendor/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+"""Loads vendored packages for path operations."""
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals, with_statement)

--- a/src/watchmaker/config/__init__.py
+++ b/src/watchmaker/config/__init__.py
@@ -5,13 +5,12 @@ from __future__ import (absolute_import, division, print_function,
 
 import collections
 import logging
-import os
 
 import yaml
 from compatibleversion import check_version
+from importlib_resources import files
 
 import watchmaker.utils.imds.detect
-from watchmaker import static
 from watchmaker.config.status import is_valid
 from watchmaker.exceptions import WatchmakerError
 from watchmaker.utils import urllib
@@ -29,26 +28,26 @@ def get_configs(system, worker_args, config_path=None):
         merged with the value of the ``"All"`` key.
 
     """
+    data = ""
     if not config_path:
         log.warning("User did not supply a config. Using the default config.")
-        config_path = os.path.join(static.__path__[0], "config.yaml")
+        data = files('watchmaker.static').joinpath('config.yaml').read_text()
     else:
         log.info("User supplied config being used.")
 
-    # Convert a local config path to a URI
-    config_path = watchmaker.utils.uri_from_filepath(config_path)
+        # Convert a local config path to a URI
+        config_path = watchmaker.utils.uri_from_filepath(config_path)
 
-    # Get the raw config data
-    data = ""
-    try:
-        data = watchmaker.utils.urlopen_retry(config_path).read()
-    except (ValueError, urllib.error.URLError):
-        msg = (
-            'Could not read config file from the provided value "{0}"! '
-            "Check that the config is available.".format(config_path)
-        )
-        log.critical(msg)
-        raise
+        # Get the raw config data
+        try:
+            data = watchmaker.utils.urlopen_retry(config_path).read()
+        except (ValueError, urllib.error.URLError):
+            msg = (
+                'Could not read config file from the provided value "{0}"! '
+                "Check that the config is available.".format(config_path)
+            )
+            log.critical(msg)
+            raise
 
     config_full = yaml.safe_load(data)
     try:

--- a/src/watchmaker/utils/__init__.py
+++ b/src/watchmaker/utils/__init__.py
@@ -132,6 +132,8 @@ def clean_none(value):
 
 def copy_subdirectories(src_dir, dest_dir, log=None):
     """Copy subdirectories within given src dir into dest dir."""
+    src_dir = str(src_dir)
+    dest_dir = str(dest_dir)
     for subdir in next(os.walk(src_dir))[1]:
         if not subdir.startswith(".") and not os.path.exists(
             os.sep.join((dest_dir, subdir))

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -236,14 +236,17 @@ class SaltBase(WorkerBase, PlatformManagerBase):
     def _get_formulas_conf(self):
 
         # Append Salt formulas bundled with Watchmaker package.
-        formulas_path = os.sep.join((static.__path__[0], 'salt', 'formulas'))
-        for formula in os.listdir(formulas_path):
-            formula_path = os.path.join(self.salt_formula_root, '', formula)
-            watchmaker.utils.copytree(
-                os.sep.join((formulas_path, formula)),
-                formula_path,
-                force=True
-            )
+        with resources.as_file(
+            resources.files(static) / 'salt' / 'formulas'
+        ) as formulas_handle:
+            formulas_path = str(formulas_handle)
+            for formula in os.listdir(formulas_path):
+                formula_path = os.sep.join((self.salt_formula_root, formula))
+                watchmaker.utils.copytree(
+                    os.sep.join((formulas_path, formula)),
+                    formula_path,
+                    force=True
+                )
 
         # Obtain & extract any Salt formulas specified in user_formulas.
         for formula_name, formula_url in self.user_formulas.items():

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -384,9 +384,9 @@ class SaltBase(WorkerBase, PlatformManagerBase):
         return failed_states
 
     def _install_pip(self, py_exec):
-        get_pip = [
-            p for p in files('watchmaker') if 'get-pip.py' in str(p)
-        ][0].locate()
+        get_pip = resources.files('watchmaker._vendor').joinpath(
+            'pypa/get-pip/public/2.7/get-pip.py'
+        )
         self.log.info(
             'Attempting pip install using get-pip (%s)...', get_pip)
         cmd = [

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -11,8 +11,8 @@ import os
 import shutil
 
 import distro
+import importlib_resources as resources
 import yaml
-from importlib_metadata import files
 
 import watchmaker.utils
 from watchmaker import static
@@ -335,11 +335,11 @@ class SaltBase(WorkerBase, PlatformManagerBase):
                 watchmaker.utils.copy_subdirectories(
                     salt_files_dir, extract_dir, self.log)
 
-        bundled_content = os.sep.join(
-            (static.__path__[0], 'salt', 'content')
-        )
-        watchmaker.utils.copy_subdirectories(
-            bundled_content, extract_dir, self.log)
+        with resources.as_file(
+            resources.files(static) / 'salt' / 'content'
+        ) as bundled_content:
+            watchmaker.utils.copy_subdirectories(
+                bundled_content, extract_dir, self.log)
 
         with codecs.open(
             os.path.join(self.salt_conf_path, 'minion'),

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -12,6 +12,7 @@ import shutil
 
 import distro
 import yaml
+from importlib_metadata import files
 
 import watchmaker.utils
 from watchmaker import static
@@ -383,15 +384,9 @@ class SaltBase(WorkerBase, PlatformManagerBase):
         return failed_states
 
     def _install_pip(self, py_exec):
-        get_pip = os.path.join(
-            os.path.abspath(
-                os.path.join(os.path.dirname(__file__), '..', '..')),
-            'vendor',
-            'pypa',
-            'get-pip',
-            'public',
-            '2.7',
-            'get-pip.py')
+        get_pip = [
+            p for p in files('watchmaker') if 'get-pip.py' in str(p)
+        ][0].locate()
         self.log.info(
             'Attempting pip install using get-pip (%s)...', get_pip)
         cmd = [

--- a/tests/test_watchmaker.py
+++ b/tests/test_watchmaker.py
@@ -3,8 +3,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals, with_statement)
 
-import os
-
+import importlib_resources as resources
 import pytest
 import yaml
 
@@ -48,7 +47,7 @@ def watchmaker_client(watchmaker_arguments):
 @pytest.fixture
 def default_config():
     """Return default configuration for watchmaker."""
-    config_path = os.path.join(static.__path__[0], 'config.yaml')
+    config_path = str(resources.files(static) / 'config.yaml')
 
     with open(config_path, 'r') as stream:
         return yaml.safe_load(stream)


### PR DESCRIPTION
Turns out the `__file__` attribute is not guaranteed to exist, and causes problems for a number of packaging solutions. See also: https://github.com/indygreg/PyOxidizer/issues/69