### PR TITLE
Ensures setup.cfg is present when updating release with windows standalone

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -145,15 +145,15 @@ jobs:
             sourceFolder: $(artifactDirFull)\dist\
         - powershell: |
             $ErrorActionPreference = "Stop"
-            $APP_VERSION = (Select-String -Path "$(artifactDir)\setup.cfg" -Pattern '^version = ').Line -replace '^(version = )(.*)$', '$2'
+            $APP_VERSION = (Select-String -Path "$(artifactDirFull)\setup.cfg" -Pattern '^version = ').Line -replace '^(version = )(.*)$', '$2'
             $APP_NAME = "watchmaker"
             $env:SATS_SLUG = "plus3it/watcmaker"
             $env:SATS_TAG = $APP_VERSION
             $env:SATS_COMMITTISH = $env:BUILD_SOURCEVERSION
             $env:SATS_BODY = "* [${APP_NAME} v${APP_VERSION} CHANGELOG](https://github.com/plus3it/${APP_NAME}/blob/${APP_VERSION}/CHANGELOG.md)"
             $env:SATS_REL_NAME = "Release v${APP_VERSION}"
-            $env:SATS_FILES_FILE = "$(artifactDir)\satsuki-files.json"
-            python -m pip install -r $(artifactDir)\deploy.txt
+            $env:SATS_FILES_FILE = "$(artifactDirFull)\satsuki-files.json"
+            python -m pip install -r "$(artifactDirFull)\deploy.txt"
             satsuki
           displayName: deploy to github with satsuki
           condition: startsWith(variables['build.sourceBranch'], 'refs/tags/')


### PR DESCRIPTION
This should fix this error:

https://dev.azure.com/plus3it/watchmaker/_build/results?buildId=5556&view=logs&j=d4aecca3-a437-5e55-8920-532a8eb17862&t=f7b8c243-3c51-5345-bbdf-15d559ac9ac1
