### PR TITLE
Releases watchmaker 0.26.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.26.1
+current_version = 0.26.2
 commit = False
 tag = False
 tag_name = {new_version}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.26.2](https://github.com/plus3it/watchmaker/releases/tag/0.26.2)
+
+**Released**: 2023.02.13
+
+**Summary**:
+
+*   Fixes publishing of Windows standalone to GitHub Releases
+*   docs
+    - Provides guidance on using S3 URL feature in config references
+    - Describes prerequisites for using AWS and Azure features
+    - Removes references to EL6 and Python 2.6
+    - Removes references to deprecated `--s3-url` argument
+*   join-domain-formula
+    - Adds support for EL8, using `sssd` to perform the domain-join
+
 ## [0.26.1](https://github.com/plus3it/watchmaker/releases/tag/0.26.1)
 
 **Released**: 2023.02.08
@@ -16,6 +31,9 @@
     Oracle Linux 8, Alma Linux 8, and Rocky Linux 8. Currently on the ash-linux
     hardening formula will work; none of the other salt formulas have yet been
     updated for EL8 support
+*   ash-windows
+    - Fixes warning in `lgpo` module about using `is` instead of `==` to compare
+      string-literal values
 
 ## 0.26.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 [metadata]
 name = watchmaker
 description = Applied Configuration Management
-version = 0.26.1
+version = 0.26.2
 long_description = file: README.md, CHANGELOG.md
 long_description_content_type = text/markdown
 author = Plus3IT Maintainers of Watchmaker


### PR DESCRIPTION
Comparison link to validate the changelog: https://github.com/plus3it/watchmaker/compare/0.26.1...main