### PR TITLE
Forces utf8 output on windows and validates json with jq

### DIFF
--- a/ci/build.ps1
+++ b/ci/build.ps1
@@ -64,9 +64,9 @@ jq -n `
     --arg wam_sha_filename "${WAM_FILENAME}.sha256" `
     --arg wam_sha_path "${PYI_DIST_DIR}\${WAM_FILENAME}.sha256" `
     --arg wam_sha_label "Watchmaker ${VERSION} Standalone Executable SHA256 Hash for Windows" `
-    -f "$SATS_TEMPLATE" > "$SATS_FILE"
+    -f "$SATS_TEMPLATE" | Out-File -Encoding utf8 "$SATS_FILE"
 
-Get-Content "$SATS_FILE"
+jq -r . "$SATS_FILE"
 
 Write-Host "Checking standalone binary version..."
 & "${PYI_DIST_DIR}/${WAM_FILENAME}.exe" --version

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -69,7 +69,7 @@ jq -n \
     --arg wam_sha_path "${PYI_DIST_DIR}/${WAM_FILENAME}.sha256" \
     --arg wam_sha_label "Watchmaker ${VERSION} Standalone Executable SHA256 Hash for Linux" \
     -f "$SATS_TEMPLATE" > "$SATS_FILE"
-cat "$SATS_FILE"
+jq -r . "$SATS_FILE"
 
 echo "Checking standalone binary version..."
 eval "${PYI_DIST_DIR}/${WAM_FILENAME}" --version


### PR DESCRIPTION
Attempting to fix errors of this form:

```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
```
See: https://dev.azure.com/plus3it/watchmaker/_build/results?buildId=5594&view=logs&j=6bb7410e-0e25-5d76-5a97-f0881e962b6a&t=73619ecc-aff5-5b8f-f008-3f1e9c5111d5&l=110

Not sure this patch is quite the right thing to do, but the error is complaining about not reading utf8, and this should force the file to be written as utf8, so 🤞 