### PR TITLE
Add "Known-findings" documentation for V-230238 (RHEL-08-010161)

### DIFF
--- a/docs/findings/el8.md
+++ b/docs/findings/el8.md
@@ -10,13 +10,13 @@
 # Findings Summary-Table
 
 ```{eval-rst}
-  .. _Prevent system daemons from using Kerberos for authentication: #prevent-system-daemons-from-using-Kerberos-for-authentication
+  .. _Prevent System Daemons From Using Kerberos For Authentication: #prevent-system-daemons-from-using-kerberos-for-authentication
 
   +-------------------------------------------------------------------------------------+---------------------+
   | Finding Summary                                                                     | Finding Identifiers |
   +=====================================================================================+=====================+
-  | Prevent System Daemons From Using Kerberos For Authentication                       | V-230238	          |
-  |                                                                                     |         	          |
+  | `Prevent System Daemons From Using Kerberos For Authentication`_                    | V-230238            |
+  |                                                                                     |                     |
   |                                                                                     | RHEL-08-010161      |
   +-------------------------------------------------------------------------------------+---------------------+
 ```

--- a/docs/findings/el8.md
+++ b/docs/findings/el8.md
@@ -1,0 +1,31 @@
+```{eval-rst}
+.. image:: ../images/cropped-plus3it-logo-cmyk.png
+   :width: 140px
+   :alt: Powered by Plus3 IT Systems
+   :align: right
+   :target: https://www.plus3it.com
+```
+<br>
+
+# Findings Summary-Table
+
+```{eval-rst}
+  .. _Prevent system daemons from using Kerberos for authentication: #prevent-system-daemons-from-using-Kerberos-for-authentication
+
+  +-------------------------------------------------------------------------------------+---------------------+
+  | Finding Summary                                                                     | Finding Identifiers |
+  +=====================================================================================+=====================+
+  | Prevent System Daemons From Using Kerberos For Authentication                       | V-230238	          |
+  |                                                                                     |         	          |
+  |                                                                                     | RHEL-08-010161      |
+  +-------------------------------------------------------------------------------------+---------------------+
+```
+
+
+# Prevent System Daemons From Using Kerberos For Authentication
+
+**Condtionally-valid Finding:**
+
+If an EL8 system is bound to Active Directory &ndash; or other Kerberos-enabled centralized authentication-source &ndash; or is _acting as_ a Kerberos domain controller (KDC), the presence of an `/etc/krb5.keytab` file is mandatory. 
+
+If the scanned system does not have the `krb5-workstation` or `krb5-server` packages installed and _any_ `.keytab` files are found in the `/etc` directory, this is a valid finding.

--- a/docs/findings/index.md
+++ b/docs/findings/index.md
@@ -22,3 +22,11 @@ configuration-state.
 
 el7.md
 ```
+
+## Common Scan Findings for EL8
+
+```{toctree}
+:maxdepth: 1
+
+el8.md
+```


### PR DESCRIPTION
- Establishes the `el8.md` document to contain "known findings" statements for EL8-based findings
- Adds link to EL8 findings-document from the findings index-file
- Provides verbiage necessary to (conditionally) address scan-findings for STIG finding-ID #V-230238 (RHEL-08-010161)

Closes #2754