### PR TITLE
Add imdsv2 support

### DIFF
--- a/src/watchmaker/config/status/__init__.py
+++ b/src/watchmaker/config/status/__init__.py
@@ -83,32 +83,32 @@ def get_providers_by_provider_types(config_status, provider_type):
     ]
 
 
-def get_sup_cloud_ids_w_prereqs(config_status):
+def get_sup_cloud_providers_w_prereqs(config_status):
     """Get supported cloud providers with prereqs and in config."""
-    supported = get_cloud_ids_with_prereqs()
+    supported = get_cloud_providers_with_prereqs()
     return list(
         set(
-            provider.get("provider_type").lower()
-            for provider in config_status.get("providers", [])
-            if provider.get("provider_type", "").lower() in supported
+            status.get("provider_type").lower()
+            for status in config_status.get("providers", [])
+            if status.get("provider_type", "").lower() in supported
         )
     )
 
 
-def get_req_cloud_ids_wo_prereqs(config_status):
+def get_req_cloud_providers_wo_prereqs(config_status):
     """Get supported cloud providers without prereqs and in config."""
-    missing_prereqs = get_cloud_ids_missing_prereqs()
+    missing_prereqs = get_cloud_providers_missing_prereqs()
     return list(
         set(
-            provider.get("provider_type").lower()
-            for provider in config_status.get("providers", [])
-            if provider.get("provider_type", "").lower() in missing_prereqs
-            and provider.get("required", False)
+            status.get("provider_type").lower()
+            for status in config_status.get("providers", [])
+            if status.get("provider_type", "").lower() in missing_prereqs
+            and status.get("required", False)
         )
     )
 
 
-def get_cloud_ids_with_prereqs():
+def get_cloud_providers_with_prereqs():
     """Get supported cloud providers with prereqs."""
     providers = set()
 
@@ -128,7 +128,7 @@ def get_cloud_ids_with_prereqs():
     return list(providers)
 
 
-def get_cloud_ids_missing_prereqs():
+def get_cloud_providers_missing_prereqs():
     """Get supported cloud providers without prereqs."""
     providers = set()
 
@@ -139,7 +139,7 @@ def get_cloud_ids_missing_prereqs():
     return list(providers)
 
 
-def get_non_cloud_identifiers(config_status):
+def get_non_cloud_providers(config_status):
     """Get unique list of other provider providers."""
     providers = set()
     for provider in SUPPORTED_NON_CLOUD_PROVIDERS:
@@ -149,9 +149,9 @@ def get_non_cloud_identifiers(config_status):
 
     return list(
         set(
-            provider.get("provider_type").lower()
-            for provider in config_status.get("providers", [])
-            if provider.get("provider_type", "").lower()
+            status.get("provider_type").lower()
+            for status in config_status.get("providers", [])
+            if status.get("provider_type", "").lower()
             in non_cloud_provider_list
         )
     )

--- a/src/watchmaker/config/status/__init__.py
+++ b/src/watchmaker/config/status/__init__.py
@@ -83,9 +83,9 @@ def get_providers_by_provider_types(config_status, provider_type):
     ]
 
 
-def get_sup_cloud_providers_w_prereqs(config_status):
+def get_supported_cloud_w_prereqs(config_status):
     """Get supported cloud providers with prereqs and in config."""
-    supported = get_cloud_providers_with_prereqs()
+    supported = get_cloud_with_prereqs()
     return list(
         set(
             status.get("provider_type").lower()
@@ -95,9 +95,9 @@ def get_sup_cloud_providers_w_prereqs(config_status):
     )
 
 
-def get_req_cloud_providers_wo_prereqs(config_status):
+def get_required_cloud_wo_prereqs(config_status):
     """Get supported cloud providers without prereqs and in config."""
-    missing_prereqs = get_cloud_providers_missing_prereqs()
+    missing_prereqs = get_cloud_missing_prereqs()
     return list(
         set(
             status.get("provider_type").lower()
@@ -108,7 +108,7 @@ def get_req_cloud_providers_wo_prereqs(config_status):
     )
 
 
-def get_cloud_providers_with_prereqs():
+def get_cloud_with_prereqs():
     """Get supported cloud providers with prereqs."""
     providers = set()
 
@@ -128,7 +128,7 @@ def get_cloud_providers_with_prereqs():
     return list(providers)
 
 
-def get_cloud_providers_missing_prereqs():
+def get_cloud_missing_prereqs():
     """Get supported cloud providers without prereqs."""
     providers = set()
 

--- a/src/watchmaker/status/__init__.py
+++ b/src/watchmaker/status/__init__.py
@@ -62,17 +62,19 @@ class Status:
                     status_config.is_provider_required(provider_type),
                 )
 
-    def get_detected_providers(self):
+    def get_detected_status_providers(self):
         """Get detected providers."""
-        return list(self.status_providers)
+        return self.status_providers
 
     def __get_status_providers(self, detected_providers):
         """Get providers by identifiers."""
         status_providers = {}
         for detected_provider in detected_providers:
-            status_providers[provider] = Status._PROVIDERS.get(
+            status_providers[
                 detected_provider.identifier
-            )(detected_provider)
+            ] = Status._PROVIDERS.get(detected_provider.identifier)(
+                detected_provider
+            )
 
         return status_providers
 

--- a/src/watchmaker/status/__init__.py
+++ b/src/watchmaker/status/__init__.py
@@ -82,11 +82,13 @@ class Status:
         """Get detected status provider ids."""
         detected_providers = []
 
-        provider = self.__detect_provider_with_prereqs(config)
+        detected_provider = self.__detect_provider_with_prereqs(config)
 
-        if provider and provider.identifier:
-            self.logger.debug("Detected provider %s", provider.identifier)
-            detected_providers.append(provider)
+        if detected_provider and detected_provider.identifier:
+            self.logger.debug(
+                "Detected provider %s", detected_provider.identifier
+            )
+            detected_providers.append(detected_provider)
         else:
             self.__error_on_required_provider(config)
 
@@ -98,7 +100,7 @@ class Status:
 
     def __detect_provider_with_prereqs(self, config):
         """Detect supported providers with prereqs."""
-        supported_providers = status_config.get_sup_cloud_providers_w_prereqs(
+        supported_providers = status_config.get_supported_cloud_w_prereqs(
             config
         )
         # Detect providers in config that have prereqs
@@ -113,7 +115,7 @@ class Status:
     def __error_on_required_provider(self, config):
         """Detect required providers in config that do no have prereqs."""
         req_providers_missing_prereqs = (
-            status_config.get_req_cloud_providers_wo_prereqs(config)
+            status_config.get_required_cloud_wo_prereqs(config)
         )
         self.logger.debug(
             "For each required provider missing "

--- a/src/watchmaker/status/__init__.py
+++ b/src/watchmaker/status/__init__.py
@@ -66,13 +66,13 @@ class Status:
         """Get detected providers."""
         return list(self.status_providers)
 
-    def __get_status_providers(self, providers):
+    def __get_status_providers(self, detected_providers):
         """Get providers by identifiers."""
         status_providers = {}
-        for provider in providers:
+        for detected_provider in detected_providers:
             status_providers[provider] = Status._PROVIDERS.get(
-                provider.identifier
-            )(provider)
+                detected_provider.identifier
+            )(detected_provider)
 
         return status_providers
 

--- a/src/watchmaker/status/providers/abstract.py
+++ b/src/watchmaker/status/providers/abstract.py
@@ -24,7 +24,7 @@ class AbstractStatusProvider:
     identifier = "unknown"
 
     @abc.abstractmethod
-    def initialize(self):
+    def initialize(self, provider):
         """Initialize provider."""
         pass  # pragma: no cover
 

--- a/src/watchmaker/status/providers/abstract.py
+++ b/src/watchmaker/status/providers/abstract.py
@@ -24,7 +24,7 @@ class AbstractStatusProvider:
     identifier = "unknown"
 
     @abc.abstractmethod
-    def initialize(self, provider):
+    def initialize(self):
         """Initialize provider."""
         pass  # pragma: no cover
 

--- a/src/watchmaker/status/providers/aws.py
+++ b/src/watchmaker/status/providers/aws.py
@@ -115,9 +115,8 @@ class AWSStatusProvider(AbstractStatusProvider):
         if AWSProvider.imds_token:
             self.logger.debug("Making IMDSv2 Call")
             return {"X-aws-ec2-metadata-token": AWSProvider.imds_token}
-        else:
-            self.logger.debug("Making IMDSv1 Call")
-            return {}
+        self.logger.debug("Making IMDSv1 Call")
+        return None
 
     def __error_on_required_status(self, required):
         """Error if tag is required."""

--- a/src/watchmaker/status/providers/aws.py
+++ b/src/watchmaker/status/providers/aws.py
@@ -28,8 +28,9 @@ class AWSStatusProvider(AbstractStatusProvider):
 
     def __init__(self, logger=None):
         self.logger = logger or logging.getLogger(__name__)
-        self.metadata_id_url = "http://169.254.169.254/latest/meta-data/instance-id"
-
+        self.metadata_id_url = (
+            "http://169.254.169.254/latest/meta-data/instance-id"
+        )
         self.metadata_region_url = (
             "http://169.254.169.254/latest/meta-data/placement/region"
         )
@@ -45,7 +46,9 @@ class AWSStatusProvider(AbstractStatusProvider):
         try:
             self.__set_details_from_server()
         except BaseException as ex:
-            self.logger.error("Error retrieving id/region from metadata service %s", ex)
+            self.logger.error(
+                "Error retrieving id/region from metadata service %s", ex
+            )
 
     def update_status(self, key, status, required):
         """Tag an AWS EC2 instance with the key and status provided."""
@@ -66,7 +69,9 @@ class AWSStatusProvider(AbstractStatusProvider):
 
     def __tag_aws_instance(self, key, status):
         """Create or update instance tag with provided status."""
-        self.logger.debug("Tag Instance %s with  %s:%s", self.instance_id, key, status)
+        self.logger.debug(
+            "Tag Instance %s with  %s:%s", self.instance_id, key, status
+        )
 
         try:
             client = boto3.client("ec2", self.region)

--- a/src/watchmaker/status/providers/aws.py
+++ b/src/watchmaker/status/providers/aws.py
@@ -44,6 +44,7 @@ class AWSStatusProvider(AbstractStatusProvider):
         if self.instance_id and self.region:
             return
         try:
+            self.logger.debug("Initialize AWS instance_id and region")
             self.instance_id = self.__get_response_from_server(
                 self.metadata_id_url
             )

--- a/src/watchmaker/status/providers/aws.py
+++ b/src/watchmaker/status/providers/aws.py
@@ -96,7 +96,7 @@ class AWSStatusProvider(AbstractStatusProvider):
 
     def __get_response_from_server(self, metadata_url):
         """Get response for provided metadata_url."""
-        headers = self.detected_provider.get_metadata_request_headers()
+        headers = self.provider.get_metadata_request_headers()
         request = utils.urllib.request.Request(
             metadata_url, data=None, headers=headers
         )

--- a/src/watchmaker/status/providers/azure.py
+++ b/src/watchmaker/status/providers/azure.py
@@ -22,7 +22,7 @@ class AzureStatusProvider(AbstractStatusProvider):
 
     identifier = "azure"
 
-    def __init__(self, logger=None):
+    def __init__(self, provider, logger=None):
         self.logger = logger or logging.getLogger(__name__)
         self.metadata_id_url = (
             "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
@@ -30,6 +30,7 @@ class AzureStatusProvider(AbstractStatusProvider):
         self.initial_status = False
         self.subscription_id = None
         self.resource_id = None
+        self.provider = provider
         self.initialize()
 
     def initialize(self):

--- a/src/watchmaker/utils/__init__.py
+++ b/src/watchmaker/utils/__init__.py
@@ -56,9 +56,8 @@ def basename_from_uri(uri):
 
 
 @backoff.on_exception(backoff.expo, urllib.error.URLError, max_tries=5)
-def urlopen_retry(uri, timeout=None, optional_headers=None, method=None):
+def urlopen_retry(uri, timeout=None, headers=None, method=None):
     """Retry urlopen on exception."""
-    request_uri = uri
     kwargs = {}
     if timeout:
         kwargs["timeout"] = timeout
@@ -72,11 +71,9 @@ def urlopen_retry(uri, timeout=None, optional_headers=None, method=None):
     except AttributeError:
         pass
 
-    if optional_headers:
-        # need to use a request object instead of string.
-        request_uri = urllib.request.Request(
-            uri, data=None, headers=optional_headers, method=method
-        )
+    request_uri = urllib.request.Request(
+        uri, data=None, headers=headers, method=method
+    )
 
     # pylint: disable=consider-using-with
     return urllib.request.urlopen(request_uri, **kwargs)

--- a/src/watchmaker/utils/__init__.py
+++ b/src/watchmaker/utils/__init__.py
@@ -56,7 +56,7 @@ def basename_from_uri(uri):
 
 
 @backoff.on_exception(backoff.expo, urllib.error.URLError, max_tries=5)
-def urlopen_retry(uri, timeout=None, headers=None, method=None):
+def urlopen_retry(uri, timeout=None):
     """Retry urlopen on exception."""
     kwargs = {}
     if timeout:
@@ -64,19 +64,17 @@ def urlopen_retry(uri, timeout=None, headers=None, method=None):
     try:
         # trust the system's default CA certificates
         # proper way for 2.7.9+ on Linux
-        if uri.startswith("https://"):
+        url = uri if isinstance(uri, str) else uri.full_url
+
+        if url.startswith("https://"):
             kwargs["context"] = ssl.create_default_context(
                 ssl.Purpose.SERVER_AUTH
             )
     except AttributeError:
         pass
 
-    request_uri = urllib.request.Request(
-        uri, data=None, headers=headers, method=method
-    )
-
     # pylint: disable=consider-using-with
-    return urllib.request.urlopen(request_uri, **kwargs)
+    return urllib.request.urlopen(uri, **kwargs)
 
 
 def copytree(src, dst, force=False, **kwargs):

--- a/src/watchmaker/utils/__init__.py
+++ b/src/watchmaker/utils/__init__.py
@@ -39,7 +39,9 @@ def uri_from_filepath(filepath):
     # Expand relative file paths and convert them to uri-style
     path = urllib.request.pathname2url(
         os.path.abspath(
-            os.path.expanduser("".join([x for x in [parts.netloc, parts.path] if x]))
+            os.path.expanduser(
+                "".join([x for x in [parts.netloc, parts.path] if x])
+            )
         )
     )
 
@@ -54,7 +56,7 @@ def basename_from_uri(uri):
 
 
 @backoff.on_exception(backoff.expo, urllib.error.URLError, max_tries=5)
-def urlopen_retry(uri, timeout=None, optional_headers={}, method=None):
+def urlopen_retry(uri, timeout=None, optional_headers=None, method=None):
     """Retry urlopen on exception."""
     request_uri = uri
     kwargs = {}
@@ -64,7 +66,9 @@ def urlopen_retry(uri, timeout=None, optional_headers={}, method=None):
         # trust the system's default CA certificates
         # proper way for 2.7.9+ on Linux
         if uri.startswith("https://"):
-            kwargs["context"] = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+            kwargs["context"] = ssl.create_default_context(
+                ssl.Purpose.SERVER_AUTH
+            )
     except AttributeError:
         pass
 
@@ -146,7 +150,9 @@ def copy_subdirectories(src_dir, dest_dir, log=None):
         if not subdir.startswith(".") and not os.path.exists(
             os.sep.join((dest_dir, subdir))
         ):
-            copytree(os.sep.join((src_dir, subdir)), os.sep.join((dest_dir, subdir)))
+            copytree(
+                os.sep.join((src_dir, subdir)), os.sep.join((dest_dir, subdir))
+            )
             if log:
                 log.info(
                     "Copied from %s to %s",

--- a/src/watchmaker/utils/imds/detect/__init__.py
+++ b/src/watchmaker/utils/imds/detect/__init__.py
@@ -53,16 +53,17 @@ def provider(supported_providers=None):
         raise CloudDetectError("Detected more than one cloud provider")
 
     if len(results) == 0:
-        return AbstractProvider.identifier
+        return AbstractProvider
 
     return results[0]
 
 
 def identify(cloud_provider):
     """Identify provider."""
-    if cloud_provider().identify():
-        return cloud_provider.identifier
+    cloud_provider_instance = cloud_provider()
+    if cloud_provider_instance.identify():
+        return cloud_provider_instance
 
     raise InvalidProviderError(
-        "Environment is not %s" % cloud_provider.identifier
+        "Environment is not %s" % cloud_provider_instance.identifier
     )

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -48,7 +48,6 @@ class AWSProvider(AbstractProvider):
 
     def __is_valid_server(self):
         """Determine if valid metadata server."""
-        """Retrieve AWS metadata."""
         data = self.__call_urlopen_retry(
             self.metadata_url,
             self.DEFAULT_TIMEOUT,

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -10,7 +10,6 @@ from __future__ import (
 
 import json
 import logging
-from os.path import exists
 
 import watchmaker.utils as utils
 from watchmaker.utils.imds.detect.providers.provider import AbstractProvider

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -32,15 +32,10 @@ class AWSProvider(AbstractProvider):
             "http://169.254.169.254/latest/api/token"
         )
 
-        self.vendor_files = (
-            "/sys/class/dmi/id/product_version",
-            "/sys/class/dmi/id/bios_vendor",
-        )
-
     def identify(self):
         """Identify AWS using all the implemented options."""
         self.logger.info("Try to identify AWS")
-        return self.check_metadata_server() or self.check_vendor_file()
+        return self.check_metadata_server()
 
     def check_metadata_server(self):
         """Identify AWS via metadata server."""
@@ -51,18 +46,6 @@ class AWSProvider(AbstractProvider):
         except BaseException as ex:
             self.logger.error(ex)
             return False
-
-    def check_vendor_file(self):
-        """Identify whether this is an AWS provider.
-
-        Checks the vendor files to see if it contains amazon.
-        """
-        self.logger.debug("Checking AWS vendor file")
-        for vendor_file in self.vendor_files:
-            data = self.__get_file_contents(vendor_file)
-            if bool(data and "amazon" in data.lower()):
-                return True
-        return False
 
     def __is_valid_server(self):
         """Determine if valid metadata server."""
@@ -94,26 +77,14 @@ class AWSProvider(AbstractProvider):
     def __request_token(self):
         try:
             self.logger.debug("Create request for token")
-            raise BaseException("Just for a test")
-            # AWSProvider.imds_token = self.__call_urlopen_retry(
-            #     self.metadata_imds_v2_token_url,
-            #     self.DEFAULT_TIMEOUT,
-            #     headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
-            #     method="PUT",
-            # )
+            AWSProvider.imds_token = self.__call_urlopen_retry(
+                self.metadata_imds_v2_token_url,
+                self.DEFAULT_TIMEOUT,
+                headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+                method="PUT",
+            )
         except BaseException as error:
             self.logger.debug("Error is %s", error)
-
-    def __get_file_contents(self, file):
-        """Get file contents if exists."""
-        if not exists(file):
-            return None
-        # Convert a local vendor file to a URI
-        file_path = utils.uri_from_filepath(file)
-        try:
-            return self.__call_urlopen_retry(file_path, self.DEFAULT_TIMEOUT)
-        except (ValueError, utils.urllib.error.URLError):
-            return None
 
     def __call_urlopen_retry(self, uri, timeout, headers=None, method=None):
         result = utils.urlopen_retry(

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -49,10 +49,6 @@ class AWSProvider(AbstractProvider):
             self.logger.error(ex)
             return False
 
-    def get_imds_token(self):
-        """Return IMDS token."""
-        return self.imds_token
-
     def get_metadata_request_headers(self):
         """Return metadata request header if imds token is set."""
         if self.imds_token:

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -20,12 +20,15 @@ class AWSProvider(AbstractProvider):
     """Concrete implementation of the AWS cloud provider."""
 
     identifier = "aws"
+    imds_token = None
 
     def __init__(self, logger=None):
         self.logger = logger or logging.getLogger(__name__)
         self.metadata_url = (
             "http://169.254.169.254/latest/dynamic/instance-identity/document"
         )
+
+        self.metadata_imds_v2_token_url = "http://169.254.169.254/latest/api/token"
 
         self.vendor_files = (
             "/sys/class/dmi/id/product_version",
@@ -60,7 +63,7 @@ class AWSProvider(AbstractProvider):
 
     def __is_valid_server(self):
         """Determine if valid metadata server."""
-        data = self.__get_data_from_server()
+        data = self.__get_server_metadata()
         if data:
             response = json.loads(data.decode("utf-8"))
             if response["imageId"].startswith(
@@ -71,11 +74,54 @@ class AWSProvider(AbstractProvider):
                 return True
         return False
 
-    def __get_data_from_server(self):
+    def __get_server_metadata(self):
         """Retrieve AWS metadata."""
-        response = utils.urlopen_retry(self.metadata_url, self.DEFAULT_TIMEOUT)
-        if response.status == 200:
-            return response.read()
+        metadata_response = None
+        try:
+            metadata_response = utils.urlopen_retry(
+                self.metadata_url,
+                self.DEFAULT_TIMEOUT,
+                optional_headers=self.__get_metadata_request_headers(),
+            )
+        except utils.urllib.error.URLError as error:
+            self.logger.debug("URLError is %s", error)
+            if (
+                "HTTP Error 401: Unauthorized" in str(error)
+                and self.__get_and_set_token()
+            ):
+                metadata_response = utils.urlopen_retry(
+                    self.metadata_url,
+                    self.DEFAULT_TIMEOUT,
+                    optional_headers=self.__get_metadata_request_headers(),
+                )
+            else:
+                raise error
+        self.logger.debug("Check metadata response is 200")
+        if metadata_response.status == 200:
+            return metadata_response.read()
+        return None
+
+    def __get_metadata_request_headers(self):
+        if AWSProvider.imds_token:
+            self.logger.debug("Making IMDSv2 Call")
+            return {"X-aws-ec2-metadata-token": AWSProvider.imds_token}
+        else:
+            self.logger.debug("Making IMDSv1 Call")
+            return {}
+
+    def __get_and_set_token(self):
+        self.logger.debug("Create request for token")
+        token_result = utils.urlopen_retry(
+            self.metadata_imds_v2_token_url,
+            self.DEFAULT_TIMEOUT,
+            optional_headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+            method="PUT",
+        )
+        if token_result.status == 200:
+            self.logger.debug("Get token result is 200")
+            AWSProvider.imds_token = token_result.read().decode("utf-8")
+            return AWSProvider.imds_token
+        self.logger.debug("Token result was not a status 200")
         return None
 
     def __get_file_contents(self, file):
@@ -85,9 +131,7 @@ class AWSProvider(AbstractProvider):
         # Convert a local vendor file to a URI
         file_path = utils.uri_from_filepath(file)
         try:
-            check_vendor_file = utils.urlopen_retry(
-                file_path, self.DEFAULT_TIMEOUT
-            )
+            check_vendor_file = utils.urlopen_retry(file_path, self.DEFAULT_TIMEOUT)
             return check_vendor_file.read()
         except (ValueError, utils.urllib.error.URLError):
             return None

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -98,9 +98,9 @@ class AWSProvider(AbstractProvider):
         if AWSProvider.imds_token:
             self.logger.debug("Making IMDSv2 Call")
             return {"X-aws-ec2-metadata-token": AWSProvider.imds_token}
-        else:
-            self.logger.debug("Making IMDSv1 Call")
-            return {}
+
+        self.logger.debug("Making IMDSv1 Call")
+        return None
 
     def __request_token(self):
         self.logger.debug("Create request for token")

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -28,7 +28,9 @@ class AWSProvider(AbstractProvider):
             "http://169.254.169.254/latest/dynamic/instance-identity/document"
         )
 
-        self.metadata_imds_v2_token_url = "http://169.254.169.254/latest/api/token"
+        self.metadata_imds_v2_token_url = (
+            "http://169.254.169.254/latest/api/token"
+        )
 
         self.vendor_files = (
             "/sys/class/dmi/id/product_version",
@@ -131,7 +133,9 @@ class AWSProvider(AbstractProvider):
         # Convert a local vendor file to a URI
         file_path = utils.uri_from_filepath(file)
         try:
-            check_vendor_file = utils.urlopen_retry(file_path, self.DEFAULT_TIMEOUT)
+            check_vendor_file = utils.urlopen_retry(
+                file_path, self.DEFAULT_TIMEOUT
+            )
             return check_vendor_file.read()
         except (ValueError, utils.urllib.error.URLError):
             return None

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -50,7 +50,17 @@ class AWSProvider(AbstractProvider):
             return False
 
     def get_imds_token(self):
+        """Return IMDS token."""
         return self.imds_token
+
+    def get_metadata_request_headers(self):
+        """Return metadata request header if imds token is set."""
+        if self.imds_token:
+            self.logger.debug("Returning AWS IMDSv2 Token Header")
+            return {"X-aws-ec2-metadata-token": self.imds_token}
+
+        self.logger.debug("AWS IMDSv2 Token not found")
+        return None
 
     def __is_valid_server(self):
         """Determine if valid metadata server."""
@@ -95,12 +105,4 @@ class AWSProvider(AbstractProvider):
         result = utils.urlopen_retry(request_uri, timeout)
         if result.status == 200:
             return result.read().decode("utf-8")
-        return None
-
-    def get_metadata_request_headers(self):
-        if self.imds_token:
-            self.logger.debug("Returning AWS IMDSv2 Token Header")
-            return {"X-aws-ec2-metadata-token": self.imds_token}
-
-        self.logger.debug("AWS IMDSv2 Token not found")
         return None

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -94,12 +94,13 @@ class AWSProvider(AbstractProvider):
     def __request_token(self):
         try:
             self.logger.debug("Create request for token")
-            AWSProvider.imds_token = self.__call_urlopen_retry(
-                self.metadata_imds_v2_token_url,
-                self.DEFAULT_TIMEOUT,
-                headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
-                method="PUT",
-            )
+            raise BaseException("Just for a test")
+            # AWSProvider.imds_token = self.__call_urlopen_retry(
+            #     self.metadata_imds_v2_token_url,
+            #     self.DEFAULT_TIMEOUT,
+            #     headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
+            #     method="PUT",
+            # )
         except BaseException as error:
             self.logger.debug("Error is %s", error)
 

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -70,7 +70,7 @@ class AWSProvider(AbstractProvider):
         data = self.__call_urlopen_retry(
             self.metadata_url,
             self.DEFAULT_TIMEOUT,
-            optional_headers=self.__get_metadata_request_headers(),
+            headers=self.__get_metadata_request_headers(),
         )
 
         if data:
@@ -97,9 +97,7 @@ class AWSProvider(AbstractProvider):
             AWSProvider.imds_token = self.__call_urlopen_retry(
                 self.metadata_imds_v2_token_url,
                 self.DEFAULT_TIMEOUT,
-                optional_headers={
-                    "X-aws-ec2-metadata-token-ttl-seconds": "21600"
-                },
+                headers={"X-aws-ec2-metadata-token-ttl-seconds": "21600"},
                 method="PUT",
             )
         except BaseException as error:

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -82,7 +82,7 @@ class AWSProvider(AbstractProvider):
                 method="PUT",
             )
         except BaseException as error:
-            self.logger.debug("Error is %s", error)
+            self.logger.debug("Failed to set IMDSv2 token: %s", error)
 
     def __call_urlopen_retry(self, uri, timeout, headers=None, method=None):
         result = utils.urlopen_retry(

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -15,7 +15,7 @@ import os
 import watchmaker.utils as utils
 from watchmaker.utils.imds.detect.providers.provider import AbstractProvider
 
-IMDS_TOKEN_TIMEOUT = os.getenv("IMDS_TOKEN_TIMEOUT", 7200)
+IMDS_TOKEN_TIMEOUT = int(os.getenv("IMDS_TOKEN_TIMEOUT", "7200"))
 
 
 class AWSProvider(AbstractProvider):
@@ -93,6 +93,7 @@ class AWSProvider(AbstractProvider):
             )
         except BaseException as error:
             self.logger.debug("Failed to set IMDSv2 token: %s", error)
+        return None
 
     def __call_urlopen_retry(self, uri, timeout, headers=None, method=None):
         request_uri = utils.urllib.request.Request(

--- a/src/watchmaker/utils/imds/detect/providers/aws_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/aws_provider.py
@@ -80,8 +80,8 @@ class AWSProvider(AbstractProvider):
         """Retrieve AWS metadata."""
         try:
             self.__request_token()
-        except utils.urllib.error.URLError as error:
-            self.logger.debug("Token URLError is %s", error)
+        except BaseException as error:
+            self.logger.debug("Error is %s", error)
 
         metadata_response = utils.urlopen_retry(
             self.metadata_url,

--- a/src/watchmaker/utils/imds/detect/providers/azure_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/azure_provider.py
@@ -9,7 +9,6 @@ from __future__ import (
 )
 
 import logging
-from os.path import exists
 
 import watchmaker.utils as utils
 from watchmaker.utils.imds.detect.providers.provider import AbstractProvider

--- a/src/watchmaker/utils/imds/detect/providers/azure_provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/azure_provider.py
@@ -25,13 +25,12 @@ class AzureProvider(AbstractProvider):
         self.metadata_url = (
             "http://169.254.169.254/metadata/instance?api-version=2021-02-01"
         )
-        self.vendor_file = "/sys/class/dmi/id/sys_vendor"
         self.headers = {"Metadata": "true"}
 
     def identify(self):
         """Identify Azure using all the implemented options."""
         self.logger.info("Try to identify Azure")
-        return self.check_vendor_file() or self.check_metadata_server()
+        return self.check_metadata_server()
 
     def check_metadata_server(self):
         """Identify Azure via metadata server."""
@@ -41,33 +40,6 @@ class AzureProvider(AbstractProvider):
         except BaseException as ex:
             self.logger.warning("Error while checking server %s", str(ex))
             return False
-
-    def check_vendor_file(self):
-        """Identify whether this in an Azure provider.
-
-        Read file /sys/class/dmi/id/sys_vendor
-        """
-        self.logger.debug("Checking Azure vendor file")
-
-        # Convert a local vendor file to a URI
-        if not exists(self.vendor_file):
-            self.logger.debug("Vendor file does not exist")
-            return False
-
-        self.logger.debug("Vendor file exists")
-        vendor_file_path = utils.uri_from_filepath(self.vendor_file)
-        try:
-            check_vendor_file = utils.urlopen_retry(
-                vendor_file_path, self.DEFAULT_TIMEOUT
-            )
-            if b"Microsoft Corporation" in check_vendor_file.read():
-                return True
-        except (ValueError, utils.urllib.error.URLError) as err:
-            self.logger.warning(
-                "Error while checking vendor file %s", str(err)
-            )
-
-        return False
 
     def __is_valid_server(self):
         """Retrieve Azure metadata."""

--- a/src/watchmaker/utils/imds/detect/providers/provider.py
+++ b/src/watchmaker/utils/imds/detect/providers/provider.py
@@ -14,14 +14,14 @@ import six
 
 
 @six.add_metaclass(abc.ABCMeta)
-class AbstractProvider():
+class AbstractProvider:
     """Abstract class representing a cloud provider.
 
     All concrete cloud providers should implement this.
     """
 
     DEFAULT_TIMEOUT = 5
-    identifier = 'unknown'
+    identifier = "unknown"
 
     @abc.abstractmethod
     def identify(self):
@@ -31,9 +31,4 @@ class AbstractProvider():
     @abc.abstractmethod
     def check_metadata_server(self):
         """Identify via metadata server."""
-        pass  # pragma: no cover
-
-    @abc.abstractmethod
-    def check_vendor_file(self):
-        """Identify via vendor file."""
         pass  # pragma: no cover

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -31,7 +31,7 @@ from watchmaker.utils.imds.detect.providers.aws_provider import AWSProvider
     "_AWSProvider__request_token",
     return_value=(None),
 )
-def test_aws_identify_is_valid(mock_urlopen, mock_request_token):
+def test_identify_is_valid(mock_urlopen, mock_request_token):
     """Test valid server data response for aws provider identification."""
     provider = AWSProvider()
     assert provider.identify() is True
@@ -49,7 +49,7 @@ def test_aws_identify_is_valid(mock_urlopen, mock_request_token):
     "_AWSProvider__request_token",
     return_value=(None),
 )
-def test_aws_check_metadata_server_is_valid(mock_urlopen, mock_request_token):
+def test_metadata_server_is_valid(mock_urlopen, mock_request_token):
     """Test valid server data response for aws provider identification."""
     provider = AWSProvider()
     assert provider.check_metadata_server() is True
@@ -67,9 +67,7 @@ def test_aws_check_metadata_server_is_valid(mock_urlopen, mock_request_token):
     "_AWSProvider__request_token",
     return_value=(None),
 )
-def test_aws_check_metadata_server_is_invalid(
-    mock_urlopen, mock_request_token
-):
+def test_metadata_server_is_invalid(mock_urlopen, mock_request_token):
     """Test invalid server data response for aws provider identification."""
     provider = AWSProvider()
     assert provider.check_metadata_server() is False
@@ -80,7 +78,7 @@ def test_aws_check_metadata_server_is_invalid(
     "_AWSProvider__call_urlopen_retry",
     return_value=("abcdefgh1234546"),
 )
-def test_aws_check_request_token(mock_urlopen):
+def test_request_token(mock_urlopen):
     """Test token is saved to imds_token."""
     provider = AWSProvider()
     assert provider.get_imds_token() == "abcdefgh1234546"
@@ -91,7 +89,7 @@ def test_aws_check_request_token(mock_urlopen):
     "_AWSProvider__call_urlopen_retry",
     return_value=(None),
 )
-def test_aws_check_request_token_none(mock_urlopen):
+def test_token_none(mock_urlopen):
     """Test token is not saved to imds_token."""
     provider = AWSProvider()
     assert provider.get_imds_token() is None

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -7,6 +7,7 @@ from __future__ import (
     unicode_literals,
     with_statement,
 )
+
 import json
 
 # Supports Python2 and Python3 test mocks
@@ -127,5 +128,5 @@ def test_aws_metadata_headers(mock_request_token, mock_urlopen):
 def test_aws_metadata_headers_none(mock_request_token, mock_urlopen):
     """Test token is not saved to imds_token."""
     provider = AWSProvider()
-    provider.get_imds_token() is None
+    assert provider.get_imds_token() is None
     assert provider.get_metadata_request_headers() is None

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -95,34 +95,3 @@ def test_aws_check_request_token_none(mock_urlopen):
     provider = AWSProvider()
     assert provider._AWSProvider__request_token() is None
     assert AWSProvider.imds_token == None
-
-
-@patch.object(
-    AWSProvider,
-    "_AWSProvider__get_file_contents",
-    return_value="provider is amazon aws",
-)
-def test_aws_valid_vendor_file(provider_mock):
-    """Tests valid vendor file."""
-    provider = AWSProvider()
-    assert provider.check_vendor_file() is True
-
-
-@patch.object(
-    AWSProvider,
-    "_AWSProvider__get_file_contents",
-    return_value="provider unknown",
-)
-def test_aws_invalid_vendor_file(provider_mock):
-    """Tests invalid vendor file."""
-    provider = AWSProvider()
-    assert provider.check_vendor_file() is False
-
-
-@patch.object(
-    AWSProvider, "_AWSProvider__get_file_contents", return_value=None
-)
-def test_aws_no_response_vendor_file(provider_mock):
-    """Tests no response while reading vendor file."""
-    provider = AWSProvider()
-    assert provider.check_vendor_file() is False

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -118,3 +118,14 @@ def test_aws_metadata_headers(mock_urlopen):
     assert provider._AWSProvider__get_metadata_request_headers() == {
         "X-aws-ec2-metadata-token": AWSProvider.imds_token
     }
+
+
+@patch.object(
+    AWSProvider,
+    "_AWSProvider__call_urlopen_retry",
+    return_value=(None),
+)
+def test_aws_metadata_headers_none(mock_urlopen):
+    """Test token is not saved to imds_token."""
+    provider = AWSProvider()
+    assert provider._AWSProvider__get_metadata_request_headers() is None

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -94,4 +94,4 @@ def test_aws_check_request_token_none(mock_urlopen):
     """Test token is not saved to imds_token."""
     provider = AWSProvider()
     assert provider._AWSProvider__request_token() is None
-    assert AWSProvider.imds_token == None
+    assert AWSProvider.imds_token is None

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -61,7 +61,9 @@ def test_aws_invalid_metadata_data_from_server(provider_mock):
     assert provider.check_metadata_server() is False
 
 
-@patch.object(AWSProvider, "_AWSProvider__get_server_metadata", return_value=(None))
+@patch.object(
+    AWSProvider, "_AWSProvider__get_server_metadata", return_value=(None)
+)
 def test_aws_no_metadata_data_from_server(provider_mock):
     """Test no server data response for aws provider identification."""
     provider = AWSProvider()
@@ -104,7 +106,9 @@ def test_aws_invalid_vendor_file(provider_mock):
     assert provider.check_vendor_file() is False
 
 
-@patch.object(AWSProvider, "_AWSProvider__get_file_contents", return_value=None)
+@patch.object(
+    AWSProvider, "_AWSProvider__get_file_contents", return_value=None
+)
 def test_aws_no_response_vendor_file(provider_mock):
     """Tests no response while reading vendor file."""
     provider = AWSProvider()

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -75,28 +75,6 @@ def test_metadata_server_is_invalid(mock_urlopen, mock_request_token):
 
 @patch.object(
     AWSProvider,
-    "_AWSProvider__call_urlopen_retry",
-    return_value=("abcdefgh1234546"),
-)
-def test_request_token(mock_urlopen):
-    """Test token is saved to imds_token."""
-    provider = AWSProvider()
-    assert provider.get_imds_token() == "abcdefgh1234546"
-
-
-@patch.object(
-    AWSProvider,
-    "_AWSProvider__call_urlopen_retry",
-    return_value=(None),
-)
-def test_token_none(mock_urlopen):
-    """Test token is not saved to imds_token."""
-    provider = AWSProvider()
-    assert provider.get_imds_token() is None
-
-
-@patch.object(
-    AWSProvider,
     "_AWSProvider__request_token",
     return_value=("abcdefgh1234546"),
 )
@@ -109,7 +87,7 @@ def test_aws_metadata_headers(mock_request_token, mock_urlopen):
     """Test token is not saved to imds_token."""
     provider = AWSProvider()
     assert provider.get_metadata_request_headers() == {
-        "X-aws-ec2-metadata-token": provider.get_imds_token()
+        "X-aws-ec2-metadata-token": "abcdefgh1234546"
     }
 
 
@@ -126,5 +104,4 @@ def test_aws_metadata_headers(mock_request_token, mock_urlopen):
 def test_aws_metadata_headers_none(mock_request_token, mock_urlopen):
     """Test token is not saved to imds_token."""
     provider = AWSProvider()
-    assert provider.get_imds_token() is None
     assert provider.get_metadata_request_headers() is None

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -16,7 +16,7 @@ except ImportError:
 
 from watchmaker.utils.imds.detect.providers.aws_provider import AWSProvider
 
-# @patch.object(AWSProvider, '_AWSProvider__get_data_from_server')
+# @patch.object(AWSProvider, '_AWSProvider__get_server_metadata')
 #     provider_mock.return_value = (
 #         '{"imageId": "ami-12312412", "instanceId": "i-ec12as"}' \
 #          .encode("utf8")
@@ -31,7 +31,7 @@ from watchmaker.utils.imds.detect.providers.aws_provider import AWSProvider
 
 @patch.object(
     AWSProvider,
-    "_AWSProvider__get_data_from_server",
+    "_AWSProvider__get_server_metadata",
     return_value=(
         '{"imageId": "ami-12312412", \
                             "instanceId": "i-ec12as"}'.encode(
@@ -47,7 +47,7 @@ def test_aws_valid_metadata_data_from_server(provider_mock):
 
 @patch.object(
     AWSProvider,
-    "_AWSProvider__get_data_from_server",
+    "_AWSProvider__get_server_metadata",
     return_value=(
         '{"imageId": "some_ID", \
                               "instanceId": "some_Instance"}'.encode(
@@ -61,9 +61,7 @@ def test_aws_invalid_metadata_data_from_server(provider_mock):
     assert provider.check_metadata_server() is False
 
 
-@patch.object(
-    AWSProvider, "_AWSProvider__get_data_from_server", return_value=(None)
-)
+@patch.object(AWSProvider, "_AWSProvider__get_server_metadata", return_value=(None))
 def test_aws_no_metadata_data_from_server(provider_mock):
     """Test no server data response for aws provider identification."""
     provider = AWSProvider()
@@ -106,9 +104,7 @@ def test_aws_invalid_vendor_file(provider_mock):
     assert provider.check_vendor_file() is False
 
 
-@patch.object(
-    AWSProvider, "_AWSProvider__get_file_contents", return_value=None
-)
+@patch.object(AWSProvider, "_AWSProvider__get_file_contents", return_value=None)
 def test_aws_no_response_vendor_file(provider_mock):
     """Tests no response while reading vendor file."""
     provider = AWSProvider()

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -82,8 +82,7 @@ def test_aws_check_metadata_server_is_invalid(
 def test_aws_check_request_token(mock_urlopen):
     """Test token is saved to imds_token."""
     provider = AWSProvider()
-    assert provider._AWSProvider__request_token() is None
-    assert AWSProvider.imds_token == "abcdefgh1234546"
+    assert provider.get_imds_token() == "abcdefgh1234546"
 
 
 @patch.object(
@@ -94,31 +93,39 @@ def test_aws_check_request_token(mock_urlopen):
 def test_aws_check_request_token_none(mock_urlopen):
     """Test token is not saved to imds_token."""
     provider = AWSProvider()
-    assert provider._AWSProvider__request_token() is None
-    assert AWSProvider.imds_token is None
+    assert provider.get_imds_token() is None
 
 
+@patch.object(
+    AWSProvider,
+    "_AWSProvider__request_token",
+    return_value=("abcdefgh1234546"),
+)
 @patch.object(
     AWSProvider,
     "_AWSProvider__call_urlopen_retry",
     return_value=(None),
 )
-def test_aws_metadata_headers(mock_urlopen):
+def test_aws_metadata_headers(mock_request_token, mock_urlopen):
     """Test token is not saved to imds_token."""
     provider = AWSProvider()
-    AWSProvider.imds_token = "abcdefgh1234546"
-    assert provider._AWSProvider__get_metadata_request_headers() == {
-        "X-aws-ec2-metadata-token": AWSProvider.imds_token
+    assert provider.get_metadata_request_headers() == {
+        "X-aws-ec2-metadata-token": provider.get_imds_token()
     }
 
 
 @patch.object(
     AWSProvider,
+    "_AWSProvider__request_token",
+    return_value=(None),
+)
+@patch.object(
+    AWSProvider,
     "_AWSProvider__call_urlopen_retry",
     return_value=(None),
 )
-def test_aws_metadata_headers_none(mock_urlopen):
+def test_aws_metadata_headers_none(mock_request_token, mock_urlopen):
     """Test token is not saved to imds_token."""
     provider = AWSProvider()
-    AWSProvider.imds_token = None
-    assert provider._AWSProvider__get_metadata_request_headers() is None
+    provider.get_imds_token() is None
+    assert provider.get_metadata_request_headers() is None

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -7,6 +7,7 @@ from __future__ import (
     unicode_literals,
     with_statement,
 )
+import json
 
 # Supports Python2 and Python3 test mocks
 try:
@@ -21,10 +22,7 @@ from watchmaker.utils.imds.detect.providers.aws_provider import AWSProvider
     AWSProvider,
     "_AWSProvider__call_urlopen_retry",
     return_value=(
-        '{"imageId": "ami-12312412", \
-                            "instanceId": "i-ec12as"}'.encode(
-            "utf8"
-        )
+        json.dumps({"imageId": "ami-12312412", "instanceId": "i-ec12as"})
     ),
 )
 @patch.object(
@@ -42,10 +40,7 @@ def test_aws_identify_is_valid(mock_urlopen, mock_request_token):
     AWSProvider,
     "_AWSProvider__call_urlopen_retry",
     return_value=(
-        '{"imageId": "ami-12312412", \
-                            "instanceId": "i-ec12as"}'.encode(
-            "utf8"
-        )
+        json.dumps({"imageId": "ami-12312412", "instanceId": "i-ec12as"})
     ),
 )
 @patch.object(
@@ -63,10 +58,7 @@ def test_aws_check_metadata_server_is_valid(mock_urlopen, mock_request_token):
     AWSProvider,
     "_AWSProvider__call_urlopen_retry",
     return_value=(
-        '{"imageId": "not-valid", \
-                            "instanceId": "etc-ec12as"}'.encode(
-            "utf8"
-        )
+        json.dumps({"imageId": "not-valid", "instanceId": "etc-ec12as"})
     ),
 )
 @patch.object(

--- a/tests/imds-providers/test_aws_provider.py
+++ b/tests/imds-providers/test_aws_provider.py
@@ -128,4 +128,5 @@ def test_aws_metadata_headers(mock_urlopen):
 def test_aws_metadata_headers_none(mock_urlopen):
     """Test token is not saved to imds_token."""
     provider = AWSProvider()
+    AWSProvider.imds_token = None
     assert provider._AWSProvider__get_metadata_request_headers() is None

--- a/tests/imds-providers/test_azure_provider.py
+++ b/tests/imds-providers/test_azure_provider.py
@@ -16,13 +16,8 @@ except ImportError:
 
 from watchmaker.utils.imds.detect.providers.azure_provider import AzureProvider
 
-# def test_reading_invalid_vendor_file():
-#     """Tests invalid vendor file."""
-#     provider = AzureProvider()
-#     assert provider.check_vendor_file() is False
 
-
-@patch.object(AzureProvider, '_AzureProvider__is_valid_server')
+@patch.object(AzureProvider, "_AzureProvider__is_valid_server")
 def test_metadata_server_check(provider_mock):
     """Tests metadata server check."""
     provider = AzureProvider()

--- a/tests/imds-providers/test_imds.py
+++ b/tests/imds-providers/test_imds.py
@@ -23,33 +23,57 @@ from watchmaker.utils.imds.detect.providers.azure_provider import AzureProvider
 
 @patch.object(AWSProvider, "identify", return_value=True)
 @patch.object(AzureProvider, "identify", return_value=False)
-def test_provider_aws(aws_provider_mock, azure_provider_mock):
+@patch.object(
+    AWSProvider,
+    "_AWSProvider__request_token",
+    return_value=(None),
+)
+def test_provider_aws(aws_provider_mock, azure_provider_mock, aws_token_mock):
     """Test provider is AWS."""
-    assert provider(["aws", "azure"]) == "aws"
+    assert provider(["aws", "azure"]).identifier == "aws"
 
 
 @patch.object(AWSProvider, "identify", return_value=False)
 @patch.object(AzureProvider, "identify", return_value=True)
-def test_provider_azure(aws_provider_mock, azure_provider_mock):
+@patch.object(
+    AWSProvider,
+    "_AWSProvider__request_token",
+    return_value=(None),
+)
+def test_provider_azure(
+    aws_provider_mock, azure_provider_mock, aws_token_mock
+):
     """Test provider is Azure."""
-    assert provider(["aws", "azure"]) == "azure"
+    assert provider(["aws", "azure"]).identifier == "azure"
 
 
 @patch.object(AWSProvider, "identify", return_value=False)
 @patch.object(AzureProvider, "identify", return_value=False)
-def test_provider_not_aws_or_azure(aws_provider_mock, azure_provider_mock):
+@patch.object(
+    AWSProvider,
+    "_AWSProvider__request_token",
+    return_value=(None),
+)
+def test_provider_not_aws_or_azure(
+    aws_provider_mock, azure_provider_mock, aws_token_mock
+):
     """Test provider is unknown."""
-    assert provider(["aws", "azure"]) == "unknown"
+    assert provider(["aws", "azure"]).identifier == "unknown"
 
 
 @patch.object(AWSProvider, "identify", return_value=False)
 @patch.object(AzureProvider, "identify", return_value=False)
-def test_none_provider(aws_provider_mock, azure_provider_mock):
+@patch.object(
+    AWSProvider,
+    "_AWSProvider__request_token",
+    return_value=(None),
+)
+def test_none_provider(aws_provider_mock, azure_provider_mock, aws_token_mock):
     """Test provider is unknown."""
-    assert provider(None) == "unknown"
+    assert provider(None).identifier == "unknown"
 
 
-@pytest.mark.skipif(True, reason="Test should be manually run.")
+@pytest.mark.skipif(False, reason="Test should be manually run.")
 def test_provider_detect():
     """Test provider is unknown."""
-    assert provider(["aws", "azure"]) == "unknown"
+    assert provider(["aws", "azure"]).identifier == "unknown"

--- a/tests/imds-providers/test_imds.py
+++ b/tests/imds-providers/test_imds.py
@@ -30,10 +30,7 @@ def test_provider_aws(aws_provider_mock, azure_provider_mock):
 
 @patch.object(AWSProvider, "identify", return_value=False)
 @patch.object(AzureProvider, "identify", return_value=True)
-@patch.object(AzureProvider, "check_vendor_file", return_value=False)
-def test_provider_azure(
-    aws_provider_mock, azure_provider_mock, azure_check_vendor_file_mock
-):
+def test_provider_azure(aws_provider_mock, azure_provider_mock):
     """Test provider is Azure."""
     assert provider(["aws", "azure"]) == "azure"
 

--- a/tests/imds-providers/test_imds.py
+++ b/tests/imds-providers/test_imds.py
@@ -73,7 +73,7 @@ def test_none_provider(aws_provider_mock, azure_provider_mock, aws_token_mock):
     assert provider(None).identifier == "unknown"
 
 
-@pytest.mark.skipif(False, reason="Test should be manually run.")
+@pytest.mark.skipif(True, reason="Test should be manually run.")
 def test_provider_detect():
     """Test provider is unknown."""
     assert provider(["aws", "azure"]).identifier == "unknown"

--- a/tests/status/test_status.py
+++ b/tests/status/test_status.py
@@ -26,7 +26,7 @@ from watchmaker.utils.imds.detect.providers.azure_provider import AzureProvider
 @patch.object(AWSProvider, "identify", return_value=True)
 @patch.object(AzureProvider, "identify", return_value=False)
 @patch(
-    "watchmaker.config.status.get_cloud_providers_with_prereqs",
+    "watchmaker.config.status.get_cloud_with_prereqs",
     return_value=["aws", "azure"],
 )
 @patch.object(
@@ -62,11 +62,11 @@ def test_status(
 @patch.object(AWSProvider, "identify", return_value=False)
 @patch.object(AzureProvider, "identify", return_value=True)
 @patch(
-    "watchmaker.config.status.get_cloud_providers_with_prereqs",
+    "watchmaker.config.status.get_cloud_with_prereqs",
     return_value=[],
 )
 @patch(
-    "watchmaker.config.status.get_cloud_providers_missing_prereqs",
+    "watchmaker.config.status.get_cloud_missing_prereqs",
     return_value=["aws", "azure"],
 )
 @patch.object(
@@ -97,8 +97,8 @@ def test_req_status_provider(
 
     try:
         Status(config_status)
-    except StatusProviderError as e:
+    except StatusProviderError as spe:
         assert (
-            str(e)
+            str(spe)
             == "Required Provider detected that is missing prereqs: azure"
         )

--- a/tests/status/test_status.py
+++ b/tests/status/test_status.py
@@ -29,8 +29,16 @@ from watchmaker.utils.imds.detect.providers.azure_provider import AzureProvider
     "watchmaker.config.status.get_cloud_providers_with_prereqs",
     return_value=["aws", "azure"],
 )
+@patch.object(
+    AWSProvider,
+    "_AWSProvider__request_token",
+    return_value=(None),
+)
 def test_status(
-    aws_provider_mock, azure_provider_mock, supported_identifiers_mock
+    aws_provider_mock,
+    azure_provider_mock,
+    supported_identifiers_mock,
+    request_token_mock,
 ):
     """Test provider is AWS."""
     data = """
@@ -61,11 +69,17 @@ def test_status(
     "watchmaker.config.status.get_cloud_providers_missing_prereqs",
     return_value=["aws", "azure"],
 )
+@patch.object(
+    AWSProvider,
+    "_AWSProvider__request_token",
+    return_value=(None),
+)
 def test_req_status_provider(
     aws_provider_mock,
     azure_provider_mock,
     supported_identifiers_mock,
     missing_prereqs_mock,
+    request_token_mock,
 ):
     """Test provider is AWS."""
     data = """

--- a/tests/status/test_status.py
+++ b/tests/status/test_status.py
@@ -54,9 +54,9 @@ def test_status(
     config = yaml.load(data, Loader=yaml.Loader)
     config_status = config.get("status", None)
     status = Status(config_status)
-    detected_providers = status.get_detected_providers()
+    detected_providers = status.get_detected_status_providers()
     assert len(detected_providers) == 1
-    assert detected_providers[0].identifier == AWSProvider.identifier
+    assert detected_providers.get("aws").identifier == AWSProvider.identifier
 
 
 @patch.object(AWSProvider, "identify", return_value=False)

--- a/tests/status/test_status.py
+++ b/tests/status/test_status.py
@@ -26,7 +26,7 @@ from watchmaker.utils.imds.detect.providers.azure_provider import AzureProvider
 @patch.object(AWSProvider, "identify", return_value=True)
 @patch.object(AzureProvider, "identify", return_value=False)
 @patch(
-    "watchmaker.config.status.get_cloud_ids_with_prereqs",
+    "watchmaker.config.status.get_cloud_providers_with_prereqs",
     return_value=["aws", "azure"],
 )
 def test_status(
@@ -48,17 +48,17 @@ def test_status(
     status = Status(config_status)
     detected_providers = status.get_detected_providers()
     assert len(detected_providers) == 1
-    assert detected_providers[0] == AWSProvider.identifier
+    assert detected_providers[0].identifier == AWSProvider.identifier
 
 
 @patch.object(AWSProvider, "identify", return_value=False)
 @patch.object(AzureProvider, "identify", return_value=True)
 @patch(
-    "watchmaker.config.status.get_cloud_ids_with_prereqs",
+    "watchmaker.config.status.get_cloud_providers_with_prereqs",
     return_value=[],
 )
 @patch(
-    "watchmaker.config.status.get_cloud_ids_missing_prereqs",
+    "watchmaker.config.status.get_cloud_providers_missing_prereqs",
     return_value=["aws", "azure"],
 )
 def test_req_status_provider(

--- a/tests/test_status_config.py
+++ b/tests/test_status_config.py
@@ -15,7 +15,6 @@ except ImportError:
     from mock import patch
 
 from watchmaker.config.status import (
-    get_cloud_providers_missing_prereqs,
     get_cloud_providers_with_prereqs,
     get_non_cloud_providers,
     get_req_cloud_providers_wo_prereqs,

--- a/tests/test_status_config.py
+++ b/tests/test_status_config.py
@@ -15,18 +15,18 @@ except ImportError:
     from mock import patch
 
 from watchmaker.config.status import (
-    get_cloud_providers_with_prereqs,
+    get_cloud_with_prereqs,
     get_non_cloud_providers,
-    get_req_cloud_providers_wo_prereqs,
-    get_sup_cloud_providers_w_prereqs,
+    get_required_cloud_wo_prereqs,
+    get_supported_cloud_w_prereqs,
 )
 
 
 @patch(
-    "watchmaker.config.status.get_cloud_providers_with_prereqs",
+    "watchmaker.config.status.get_cloud_with_prereqs",
     return_value=["aws", "azure"],
 )
-def test_get_supported_cloud_identifiers_with_prereqs(prereqs):
+def test_supported_cloud_w_prereqs(prereqs):
     """Test get required ids that are have prereqs."""
     config_status = {
         "providers": [
@@ -48,7 +48,7 @@ def test_get_supported_cloud_identifiers_with_prereqs(prereqs):
         ]
     }
 
-    ids = get_sup_cloud_providers_w_prereqs(config_status)
+    ids = get_supported_cloud_w_prereqs(config_status)
 
     assert ids is not None
     assert "aws" in ids
@@ -58,10 +58,10 @@ def test_get_supported_cloud_identifiers_with_prereqs(prereqs):
 
 
 @patch(
-    "watchmaker.config.status.get_cloud_providers_missing_prereqs",
+    "watchmaker.config.status.get_cloud_missing_prereqs",
     return_value=["aws", "azure"],
 )
-def test_get_required_cloud_identifiers_missing_prereqs(prereqs):
+def test_req_cloud_wo_prereqs(prereqs):
     """Test get required ids that are missing prereqs."""
     config_status = {
         "providers": [
@@ -83,7 +83,7 @@ def test_get_required_cloud_identifiers_missing_prereqs(prereqs):
         ]
     }
 
-    ids = get_req_cloud_providers_wo_prereqs(config_status)
+    ids = get_required_cloud_wo_prereqs(config_status)
 
     assert ids is not None
     assert "aws" not in ids
@@ -93,10 +93,10 @@ def test_get_required_cloud_identifiers_missing_prereqs(prereqs):
 
 
 @patch(
-    "watchmaker.config.status.get_cloud_providers_missing_prereqs",
+    "watchmaker.config.status.get_cloud_missing_prereqs",
     return_value=[],
 )
-def test_no_required_cloud_identifiers_missing_prereqs(prereqs):
+def test_no_req_cloud_wo_prereqs(prereqs):
     """Test get required ids that are missing prereqs."""
     config_status = {
         "providers": [
@@ -118,9 +118,7 @@ def test_no_required_cloud_identifiers_missing_prereqs(prereqs):
         ]
     }
 
-    providers = get_req_cloud_providers_wo_prereqs(config_status)
-
-    assert providers == []
+    assert not get_required_cloud_wo_prereqs(config_status)
 
 
 @patch(
@@ -130,9 +128,9 @@ def test_no_required_cloud_identifiers_missing_prereqs(prereqs):
         {"provider": "azure", "has_prereq": False},
     ],
 )
-def test_get_cloud_providers_with_prereqs():
+def test_get_cloud_with_prereqs():
     """Test get ids with prereqs."""
-    providers = get_cloud_providers_with_prereqs()
+    providers = get_cloud_with_prereqs()
 
     assert len(providers) == 1
     assert "aws" == providers[0]
@@ -145,9 +143,9 @@ def test_get_cloud_providers_with_prereqs():
         {"provider": "azure", "has_prereq": False},
     ],
 )
-def test_get_cloud_ids_missing_prereqs():
+def test_cloud_ids_missing_prereqs():
     """Test get ids missing prereqs."""
-    providers = get_cloud_providers_with_prereqs()
+    providers = get_cloud_with_prereqs()
 
     assert len(providers) == 1
     assert "azure" != providers[0]
@@ -187,7 +185,7 @@ def test_get_non_cloud_providers():
     "watchmaker.config.status.SUPPORTED_NON_CLOUD_PROVIDERS",
     [],
 )
-def test_get_empty_non_cloud_identifiers():
+def test_no_non_cloud_providers():
     """Test empty SUPPORTED_NON_CLOUD_PROVIDERS."""
     config_status = {
         "providers": [
@@ -204,6 +202,4 @@ def test_get_empty_non_cloud_identifiers():
         ]
     }
 
-    providers = get_non_cloud_providers(config_status)
-
-    assert providers == []
+    assert not get_non_cloud_providers(config_status)

--- a/tests/test_status_config.py
+++ b/tests/test_status_config.py
@@ -15,16 +15,16 @@ except ImportError:
     from mock import patch
 
 from watchmaker.config.status import (
-    get_cloud_ids_missing_prereqs,
-    get_cloud_ids_with_prereqs,
-    get_non_cloud_identifiers,
-    get_req_cloud_ids_wo_prereqs,
-    get_sup_cloud_ids_w_prereqs,
+    get_cloud_providers_missing_prereqs,
+    get_cloud_providers_with_prereqs,
+    get_non_cloud_providers,
+    get_req_cloud_providers_wo_prereqs,
+    get_sup_cloud_providers_w_prereqs,
 )
 
 
 @patch(
-    "watchmaker.config.status.get_cloud_ids_with_prereqs",
+    "watchmaker.config.status.get_cloud_providers_with_prereqs",
     return_value=["aws", "azure"],
 )
 def test_get_supported_cloud_identifiers_with_prereqs(prereqs):
@@ -49,7 +49,7 @@ def test_get_supported_cloud_identifiers_with_prereqs(prereqs):
         ]
     }
 
-    ids = get_sup_cloud_ids_w_prereqs(config_status)
+    ids = get_sup_cloud_providers_w_prereqs(config_status)
 
     assert ids is not None
     assert "aws" in ids
@@ -59,7 +59,7 @@ def test_get_supported_cloud_identifiers_with_prereqs(prereqs):
 
 
 @patch(
-    "watchmaker.config.status.get_cloud_ids_missing_prereqs",
+    "watchmaker.config.status.get_cloud_providers_missing_prereqs",
     return_value=["aws", "azure"],
 )
 def test_get_required_cloud_identifiers_missing_prereqs(prereqs):
@@ -84,7 +84,7 @@ def test_get_required_cloud_identifiers_missing_prereqs(prereqs):
         ]
     }
 
-    ids = get_req_cloud_ids_wo_prereqs(config_status)
+    ids = get_req_cloud_providers_wo_prereqs(config_status)
 
     assert ids is not None
     assert "aws" not in ids
@@ -94,7 +94,7 @@ def test_get_required_cloud_identifiers_missing_prereqs(prereqs):
 
 
 @patch(
-    "watchmaker.config.status.get_cloud_ids_missing_prereqs",
+    "watchmaker.config.status.get_cloud_providers_missing_prereqs",
     return_value=[],
 )
 def test_no_required_cloud_identifiers_missing_prereqs(prereqs):
@@ -119,9 +119,9 @@ def test_no_required_cloud_identifiers_missing_prereqs(prereqs):
         ]
     }
 
-    ids = get_req_cloud_ids_wo_prereqs(config_status)
+    providers = get_req_cloud_providers_wo_prereqs(config_status)
 
-    assert ids == []
+    assert providers == []
 
 
 @patch(
@@ -131,13 +131,12 @@ def test_no_required_cloud_identifiers_missing_prereqs(prereqs):
         {"provider": "azure", "has_prereq": False},
     ],
 )
-def test_get_cloud_ids_with_prereqs():
+def test_get_cloud_providers_with_prereqs():
     """Test get ids with prereqs."""
-    ids = get_cloud_ids_with_prereqs()
+    providers = get_cloud_providers_with_prereqs()
 
-    assert ids is not None
-    assert "aws" in ids
-    assert "azure" not in ids
+    assert len(providers) == 1
+    assert "aws" == providers[0]
 
 
 @patch(
@@ -149,11 +148,10 @@ def test_get_cloud_ids_with_prereqs():
 )
 def test_get_cloud_ids_missing_prereqs():
     """Test get ids missing prereqs."""
-    ids = get_cloud_ids_missing_prereqs()
+    providers = get_cloud_providers_with_prereqs()
 
-    assert ids is not None
-    assert "aws" not in ids
-    assert "azure" in ids
+    assert len(providers) == 1
+    assert "azure" != providers[0]
 
 
 @patch(
@@ -163,7 +161,7 @@ def test_get_cloud_ids_missing_prereqs():
         {"provider": "db"},
     ],
 )
-def test_get_non_cloud_identifiers():
+def test_get_non_cloud_providers():
     """Test get non cloud identifiers matching config."""
     config_status = {
         "providers": [
@@ -180,11 +178,10 @@ def test_get_non_cloud_identifiers():
         ]
     }
 
-    ids = get_non_cloud_identifiers(config_status)
+    providers = get_non_cloud_providers(config_status)
 
-    assert ids is not None
-    assert "sqs" not in ids
-    assert "file" in ids
+    assert len(providers) == 1
+    assert "file" == providers[0]
 
 
 @patch(
@@ -208,6 +205,6 @@ def test_get_empty_non_cloud_identifiers():
         ]
     }
 
-    ids = get_non_cloud_identifiers(config_status)
+    providers = get_non_cloud_providers(config_status)
 
-    assert ids == []
+    assert providers == []


### PR DESCRIPTION
This PR adds support for imdsv2 token headers for AWS. It defaults to v2 if present otherwise will attempt v1 if unable to access token.

The detection based on vendor files is also removed for both AWS and Azure as both status providers require accessing the metadata server to function properly.  