### PR TITLE
Update FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -139,6 +139,29 @@ And then rebooting the system.
 
 ## How do I get Watchmaker release/project notifications?
 
-Users may use an RSS reader of their choice to subscribe to the Watchmaker Release feed to get notifications on Watchmaker releases. The Watchmaker RSS release feed is https://github.com/plus3it/watchmaker/releases.atom.
+Users may use an RSS reader of their choice to subscribe to the Watchmaker
+Release feed to get notifications on Watchmaker releases. The Watchmaker RSS
+release feed is https://github.com/plus3it/watchmaker/releases.atom.
 
-Users can also "watch" the GitHub project to receive notifications on all project activity, https://github.com/plus3it/watchmaker/subscription.
+Users can also "watch" the GitHub project to receive notifications on all
+project activity, https://github.com/plus3it/watchmaker/subscription.
+
+## Why do I get warnings in my system logs about the rsyslog service not being able to connect to the `logcollector` host
+
+Watchmaker leverages the `oscap` utility and associated OSCAP content for a
+significant percentage of its hardening-actions. Recent updates to this content
+have included (inappropriately) adding:
+
+~~~
+# Per CCE-80863-4: Set *.* @@logcollector in /etc/rsyslog.conf
+*.* @@logcollector
+~~~
+
+To the `/etc/rsyslog.conf` file. The `*.* @@logcollector` line results in the
+`rsyslog` service attempting to do remote-logging to the external host
+`logcollector`. If no such hostname exists in the hardened-system's DNS domain,
+"host not found" error-types will be logged. If using a log-offloader tool
+(such as the Splunk forwarder-agent), it is safe to either comment out the `*.*
+@@logcollector`. If data _should_ be sent directly from `rsyslog` to a remote
+syslog-host, change the string `logcollector` to the FQDN of your site's actual
+log-collector host.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,6 +22,21 @@ the output of a failed installation. Usually, the output points pretty clearly
 at the source of the problem. Watchmaker can be re-installed over itself with
 no problem, so once the root cause is resolved, simply re-install watchmaker.
 
+## Why does watchmaker immediately fail to run on my spel-based system?
+
+System-images created using [spel](https://github.com/plus3it/spel/) enable
+SELinux role-transitions for all local/baked-in user accounts. This includes
+the provisioning-users created at launchtime by the `cloud-init` utility. These
+users are created with the default SELinux context of
+`staff_u:staff_r:staff_t:s0-s0:c0.c1023`. Their default role-transition can
+result in the user not having enough privileges to run watchmaker. To work
+around any watchmaker-killing "permission denied" errors this may cause,
+escalate privileges using `sudo -i -r unconfined_r -t unconfined_t`.
+
+Note: this should only impact processes that are not initiated via `systemd`
+(i.e., should not impact provisioning-processes kicked off via userData,
+CloudFormation or the like).
+
 ## Why does the watchmaker install fail if my system is FIPS enabled?
 
 This is primarily a question for Red Hat (and derived distributions). As of this
@@ -69,6 +84,13 @@ page for a list of all supported operating systems.
 Watchmaker is supported on RedHat 8, CentOS 8 Stream, and Oracle Linux 8. See the
 [index](index) page for a list of all supported operating systems.
 
+## Does watchmaker support Enterprise Linux 9?
+
+As of today's date (2024-04-10), watchmaker's hardening-modules do not yet
+support Enterprise Linux 9 or related distros. This is currently a
+to-be-started project-task. Action on support for Enterprise Linux 9-based
+distros can be tracked through [ash-linux-formula issue #496](https://github.com/plus3it/ash-linux-formula/issues/496).
+
 ## How can I exclude salt states when executing watchmaker?
 
 The Salt worker in Watchmaker supports an `exclude_states` argument. When
@@ -105,50 +127,15 @@ salt-call -c /opt/watchmaker/salt state.show_top
 
 ## Can I use watchmaker to toggle my RedHat/Centos host's FIPS mode?
 
-Yes, indirectly. Because watchmaker implements most of its functionality via
-[SaltStack](https://saltproject.io/) modules, you can directly-use the underlying
-SaltStack functionality to effect the desired change. This is done from the
-commandline - as root - by executing:
+For Enterprise Linux, "yes, indirectly". Because watchmaker implements most of
+its functionality via [SaltStack](https://saltproject.io/) modules, you can
+directly-use the underlying SaltStack functionality to effect the desired
+change. This is done from the commandline - as root - by executing:
 
 *   Disable FIPS-mode: `salt-call -c /opt/watchmaker/salt ash.fips_disable`
 *   Enable FIPS-mode: `salt-call -c /opt/watchmaker/salt ash.fips_enable`
 
 And then rebooting the system.
-
-## How do I install watchmaker when I am using Python 2.6?
-
-While Watchmaker no longer offically supports Python 2.6, you may use the last
-version where it was tested, Watchmaker 0.21.7. That version includes pins on
-dependencies that will work for Python 2.6.
-
-However, there are three python "setup" packages needed just to install ``watchmaker``,
-and these packages cannot be platform-restricted within the ``watchmaker`` package
-specification.
-
-Below is the list of packages in question, and the versions that no longer
-support Python 2.6:
-
-*   ``pip>=10``
-*   ``wheel>=0.30.0``
-*   ``setuptools>=37``
-
-In order to install pip in Python 2.6, you can get it from:
-
-*   <https://bootstrap.pypa.io/pip/2.6/get-pip.py>
-
-Once a Python 2.6-compatible ``pip`` version is installed, you can install
-compatible versions of the other packages like this:
-
-```shell
-python -m pip install --upgrade "pip<10" "wheel<0.30.0" "setuptools<37"
-```
-
-You can then [install watchmaker](installation) by restricting the watchmaker
-version to the last version tested with Python 2.6:
-
-```shell
-python -m pip install "watchmaker==0.21.7"
-```
 
 ## How do I get Watchmaker release/project notifications?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -165,3 +165,20 @@ To the `/etc/rsyslog.conf` file. The `*.* @@logcollector` line results in the
 @@logcollector`. If data _should_ be sent directly from `rsyslog` to a remote
 syslog-host, change the string `logcollector` to the FQDN of your site's actual
 log-collector host.
+
+## Why isn't the domain-join functionality doing DDNS updates
+
+Starting in early 2023, the default method for joining Linux hosts to Active
+Directory domains was changed to leveraging the native, `sssd`-based
+integrations. While `sssd` has the capability of doing DDNS updates (and doing
+regular refreshes to prevent record-loss due to record-scavenging), it has a
+couple of requirements in order to be able to do so. First and foremost is that
+the hosts providing DNS service to the Linux system have DDNS enabled for the A
+and PTR zones the Linux system is a member of. Similarly, `sssd` defaults to
+attempting to use GSS with TSIG for its DDNS update-requests: even if the Linux
+system's A and PTR zones are DDNS-enabled, if those zones don't allow DDNS
+clients to negotiate updates with GSS and TSIG, the updates will fail.
+Watchmaker's `join-domain-formlul` (for `sssd`) _does_ allow overriding the
+attempt to negotiate updates with GSS and TSIG. This is done by appending
+`dyndns_auth: none` (and, optionally, adding `dyndns_auth_ptr: none`) to the
+Salt pillar's `sssd_conf_parameters` parameter-value.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -178,7 +178,7 @@ and PTR zones the Linux system is a member of. Similarly, `sssd` defaults to
 attempting to use GSS with TSIG for its DDNS update-requests: even if the Linux
 system's A and PTR zones are DDNS-enabled, if those zones don't allow DDNS
 clients to negotiate updates with GSS and TSIG, the updates will fail.
-Watchmaker's `join-domain-formlul` (for `sssd`) _does_ allow overriding the
+Watchmaker's `join-domain-formula` (for `sssd`) _does_ allow overriding the
 attempt to negotiate updates with GSS and TSIG. This is done by appending
 `dyndns_auth: none` (and, optionally, adding `dyndns_auth_ptr: none`) to the
 Salt pillar's `sssd_conf_parameters` parameter-value.


### PR DESCRIPTION
Closes #3330

- Add note about oscap and rsyslog-config
- Add entries for `/boot's` mount-options
- Add entries for seeing what oscap does
- Add note about sssd's `dyndns_auth` and `dyndns_auth_ptr` options' values
- Eliminate stale content for Python 2.6 issues (no longer relevant since deprecation of support for EL6-based systems)
- Update note about FIPS mode toggling: necessary since EL8 and EL9 now use FIPS mode-setting method that's no longer compatible with how ash-linux-formula effectuated the mode-toggle under EL6 and EL7
- Add note for interactive-execution of watchmaker under spel-built system-images' SELinux configuration
