### PR TITLE
Add Baseline Support for Running Watchmaker on `al2023` Instances

### DIFF
--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -674,7 +674,7 @@ class SaltLinux(SaltBase, LinuxPlatformManager):
         ]
 
         # Add distro-specific policycoreutils RPM to package-list
-        self.yum_pkgs.append(self._policy_rpm(distro.version()[0]))
+        self.yum_pkgs.append(self._policy_rpm(distro.version().split('.')[0]))
 
         # Set up variables for paths to Salt directories and applications.
         self.salt_call = "/usr/bin/salt-call"
@@ -804,7 +804,7 @@ class SaltLinux(SaltBase, LinuxPlatformManager):
 
     def _policy_rpm(self, arg):
         """Return name of distro version-appropriate policycoreutils RPM."""
-        if arg < "8":
+        if int(arg) < 8:
             result = "policycoreutils-python"
         else:
             result = "policycoreutils-python-utils"

--- a/src/watchmaker/workers/salt.py
+++ b/src/watchmaker/workers/salt.py
@@ -278,7 +278,6 @@ class SaltBase(WorkerBase, PlatformManagerBase):
         return False
 
     def _get_formulas_conf(self):
-
         # Append Salt formulas bundled with Watchmaker package.
         with resources.as_file(
             resources.files(static) / "salt" / "formulas"
@@ -674,7 +673,7 @@ class SaltLinux(SaltBase, LinuxPlatformManager):
         ]
 
         # Add distro-specific policycoreutils RPM to package-list
-        self.yum_pkgs.append(self._policy_rpm(distro.version().split('.')[0]))
+        self.yum_pkgs.append(self._policy_rpm(distro.version().split(".")[0]))
 
         # Set up variables for paths to Salt directories and applications.
         self.salt_call = "/usr/bin/salt-call"
@@ -723,7 +722,6 @@ class SaltLinux(SaltBase, LinuxPlatformManager):
         if self.install_method.lower() == "yum":
             self._install_from_yum(self.yum_pkgs)
         elif self.install_method.lower() == "git":
-
             salt_bootstrap_filename = os.sep.join(
                 (
                     self.working_dir,

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -31,6 +31,7 @@ class Yum(WorkerBase, LinuxPlatformManager):
     SUPPORTED_DISTS = {
         "almalinux": "almalinux",
         "amazon": "amazon",
+        "amzn": "al2023",
         "centos": "centos",
         "oracle": "oracle",
         "rhel": "redhat",
@@ -54,14 +55,14 @@ class Yum(WorkerBase, LinuxPlatformManager):
     def get_dist_info(self):
         """Validate the Linux distro and return info about the distribution."""
         dist = self.get_mapped_dist_name()
-        version = distro.version()[0]
+        version = distro.version().split('.')[0]
         el_version = None
 
         # Determine el_version
         if dist == "amazon":
             el_version = self._get_amazon_el_version(version)
         else:
-            el_version = distro.version()[0]
+            el_version = distro.version().split('.')[0]
 
         if el_version is None:
             msg = "Unsupported OS version! dist = {0}, version = {1}.".format(

--- a/src/watchmaker/workers/yum.py
+++ b/src/watchmaker/workers/yum.py
@@ -55,14 +55,14 @@ class Yum(WorkerBase, LinuxPlatformManager):
     def get_dist_info(self):
         """Validate the Linux distro and return info about the distribution."""
         dist = self.get_mapped_dist_name()
-        version = distro.version().split('.')[0]
+        version = distro.version().split(".")[0]
         el_version = None
 
         # Determine el_version
         if dist == "amazon":
             el_version = self._get_amazon_el_version(version)
         else:
-            el_version = distro.version().split('.')[0]
+            el_version = distro.version().split(".")[0]
 
         if el_version is None:
             msg = "Unsupported OS version! dist = {0}, version = {1}.".format(


### PR DESCRIPTION
Updates the `yum.py` and `salt.py` to allow watchmaker to install appropriate dependencies for hosts running the `al2023` operating system. 

Note: because none of the formulae that the default watchmaker configuration runs are `al2023`-enabled, watchmaker will run until attempting to execute formulae, then fail (i.e., the `/var/log/watchmaker/salt_call.debug.log` file gets created).

Closes #3494 