### PR TITLE
Detail finding-underpinnings

### DIFF
--- a/docs/findings/el9.md
+++ b/docs/findings/el9.md
@@ -397,10 +397,16 @@ In either case, the scanner will flag the mappings as being incorrect. However, 
 
 **Invalid Finding:**
 
+## Brittle Scan
+
 Some scanners may call out this setting as incorrect, even if correctly-set.
 
 Watchmaker _sets_ the correct value, but some scanners use an incorrect validation-method to check the setting.
 
 * It is known that the `oscap` utility's scan-regex &mdash; derived from the Compliance as Code project's content &mdash; is faulty. A [bug](https://github.com/ComplianceAsCode/content/issues/13891) has been submitted against the project. Projects that leverage this project's contents will likely also indicate a spurious non-compliance finding.
+
+## Inflexible (Too Strict) Scan
+
+When using the default scan-content from the oscap utility (and possibly other tooling), the scan-findings will report clean _only_ if the `smtpd_client_restrictions` Postfix parameter's value is set to "`permit_mynetworks,reject`". Any deviation from this, even to ones that are _more_ restrictive, can result in a finding that is spurious for the actual intent of the scan.
 
 [^1]: Do not try to perform an exact-match from the scan-report to this table. The findings table's link-titles are distillations of the scan-findings title-text rather than being verbatim copies.


### PR DESCRIPTION
There are actually two problems with the scan-findings:

- The first &mdash; enumerated in 6b4f5ef &mdash; dealt with a "too brittle" condition in the scanning regex
- The second is being covered in this commit and deals with an overly-strict scanning regex that declares that even extra-restrictive configurations are non-compliant